### PR TITLE
add _missing_ function to DeviceType class

### DIFF
--- a/src/pyatmo/modules/device_types.py
+++ b/src/pyatmo/modules/device_types.py
@@ -114,9 +114,12 @@ class DeviceType(str, Enum):
     # pylint: enable=C0103
 
     @classmethod
-    def _missing_(cls,key):
-        LOG.warning(f"{key} device is unknown")
-        return DeviceType("NLunknown")
+    def _missing_(cls, key):
+        """Handle unknown device types."""
+
+        msg = f"{key} device is unknown"
+        LOG.warning(msg)
+        return DeviceType.NLunknown
 
 class DeviceCategory(str, Enum):
     """Class to represent Netatmo device types."""

--- a/src/pyatmo/modules/device_types.py
+++ b/src/pyatmo/modules/device_types.py
@@ -121,6 +121,7 @@ class DeviceType(str, Enum):
         LOG.warning(msg)
         return DeviceType.NLunknown
 
+
 class DeviceCategory(str, Enum):
     """Class to represent Netatmo device types."""
 

--- a/src/pyatmo/modules/device_types.py
+++ b/src/pyatmo/modules/device_types.py
@@ -113,6 +113,10 @@ class DeviceType(str, Enum):
 
     # pylint: enable=C0103
 
+    @classmethod
+    def _missing_(cls,key):
+        LOG.warning(f"{key} device is unknown")
+        return DeviceType("NLunknown")
 
 class DeviceCategory(str, Enum):
     """Class to represent Netatmo device types."""


### PR DESCRIPTION
Add _missing_ class method on DeviceType class to return NLunknown  for pyatmo unknown devices
This will warn on system logging but not die