### PR TITLE
add missing device type mapping for NIS

### DIFF
--- a/src/pyatmo/modules/device_types.py
+++ b/src/pyatmo/modules/device_types.py
@@ -196,6 +196,7 @@ DEVICE_CATEGORY_MAP: dict[DeviceType, DeviceCategory] = {
     DeviceType.NLJ: DeviceCategory.shutter,
     DeviceType.BNIL: DeviceCategory.switch,
     DeviceType.BNLD: DeviceCategory.dimmer,
+    DeviceType.NIS: DeviceCategory.siren,
 }
 
 


### PR DESCRIPTION
resolves: https://github.com/jabesq-org/pyatmo/issues/475