### PR TITLE
Improve BTicino support

### DIFF
--- a/src/pyatmo/modules/bticino.py
+++ b/src/pyatmo/modules/bticino.py
@@ -4,7 +4,14 @@ from __future__ import annotations
 
 import logging
 
-from pyatmo.modules.module import Dimmer, Module, Shutter, Switch
+from pyatmo.modules.module import (
+    DimmableMixin,
+    Module,
+    Shutter,
+    ShutterMixin,
+    Switch,
+    SwitchMixin,
+)
 
 LOG = logging.getLogger(__name__)
 
@@ -37,7 +44,7 @@ class BNMS(Shutter):
     """BTicino motorized shade."""
 
 
-class BNAS(Shutter):
+class BNAS(ShutterMixin, Module):
     """BTicino automatic shutter."""
 
 
@@ -61,9 +68,9 @@ class BNTR(Module):
     """BTicino radiator thermostat."""
 
 
-class BNIL(Switch):
-    """BTicino itelligent light."""
+class BNIL(SwitchMixin, Module):
+    """BTicino intelligent light."""
 
 
-class BNLD(Dimmer):
+class BNLD(DimmableMixin, SwitchMixin, Module):
     """BTicino dimmer light."""

--- a/src/pyatmo/room.py
+++ b/src/pyatmo/room.py
@@ -93,7 +93,11 @@ class Room(NetatmoBase):
 
         self.heating_power_request = raw_data.get("heating_power_request")
         self.humidity = raw_data.get("humidity")
-        self.reachable = raw_data.get("reachable")
+        if self.climate_type == DeviceType.BNTH:
+            # BNTH is wired, so the room is always reachable
+            self.reachable = True
+        else:
+            self.reachable = raw_data.get("reachable")
         self.therm_measured_temperature = raw_data.get("therm_measured_temperature")
         self.therm_setpoint_mode = raw_data.get("therm_setpoint_mode")
         self.therm_setpoint_temperature = raw_data.get("therm_setpoint_temperature")

--- a/src/pyatmo/room.py
+++ b/src/pyatmo/room.py
@@ -85,6 +85,8 @@ class Room(NetatmoBase):
         elif "BNS" in self.device_types:
             self.climate_type = DeviceType.BNS
             self.features.add("humidity")
+        elif "BNTH" in self.device_types:
+            self.climate_type = DeviceType.BNTH
 
     def update(self, raw_data: RawData) -> None:
         """Update room data."""


### PR DESCRIPTION
Improves overall BTicino support for various devices:

* set base classes for BNAS, BNIL and BNDL devices explicitly, omitting firmware and power mixins as these devices provide neither
* set the climate_type property of a room correctly if the climate feature is provided by a BNTH device
* set reachable property to True if climate is provided via BNTH device