### PR TITLE
Add preferred position functionnality to shutter

### DIFF
--- a/src/pyatmo/modules/module.py
+++ b/src/pyatmo/modules/module.py
@@ -403,6 +403,11 @@ class FanSpeedMixin(EntityBase):
 class ShutterMixin(EntityBase):
     """Mixin for shutter data."""
 
+    __open_position = 100
+    __close_position = 0
+    __stop_position = -1
+    __preferred_position = -2
+
     def __init__(self, home: Home, module: ModuleT):
         """Initialize shutter mixin."""
 
@@ -414,14 +419,15 @@ class ShutterMixin(EntityBase):
         """Set shutter to target position."""
 
         # in case of a too low value, we default to stop and not the preferred position
-        if target_position < -2:
-            target_position = -1
+        # We check against __preferred_position that is the lower known value
+        if target_position < self.__preferred_position:
+            target_position = self.__stop_position
 
         json_roller_shutter = {
             "modules": [
                 {
                     "id": self.entity_id,
-                    "target_position": min(100, target_position),
+                    "target_position": min(self.__open_position, target_position),
                     "bridge": self.bridge,
                 },
             ],
@@ -431,22 +437,22 @@ class ShutterMixin(EntityBase):
     async def async_open(self) -> bool:
         """Open shutter."""
 
-        return await self.async_set_target_position(100)
+        return await self.async_set_target_position(self.__open_position)
 
     async def async_close(self) -> bool:
         """Close shutter."""
 
-        return await self.async_set_target_position(0)
+        return await self.async_set_target_position(self.__close_position)
 
     async def async_stop(self) -> bool:
         """Stop shutter."""
 
-        return await self.async_set_target_position(-1)
+        return await self.async_set_target_position(self.__stop_position)
 
-    async def async_preferred_position(self) -> bool:
+    async def async_move_to_preferred_position(self) -> bool:
         """Move shutter to preferred position."""
 
-        return await self.async_set_target_position(-2)
+        return await self.async_set_target_position(self.__preferred_position)
 
 
 class CameraMixin(EntityBase):

--- a/src/pyatmo/modules/module.py
+++ b/src/pyatmo/modules/module.py
@@ -413,11 +413,15 @@ class ShutterMixin(EntityBase):
     async def async_set_target_position(self, target_position: int) -> bool:
         """Set shutter to target position."""
 
+        # in case of a too low value, we default to stop and not the preferred position
+        if target_position < -2:
+            target_position = -1
+
         json_roller_shutter = {
             "modules": [
                 {
                     "id": self.entity_id,
-                    "target_position": max(min(100, target_position), -1),
+                    "target_position": min(100, target_position),
                     "bridge": self.bridge,
                 },
             ],
@@ -438,6 +442,11 @@ class ShutterMixin(EntityBase):
         """Stop shutter."""
 
         return await self.async_set_target_position(-1)
+
+    async def async_preferred_position(self) -> bool:
+        """Move shutter to preferred position."""
+
+        return await self.async_set_target_position(-2)
 
 
 class CameraMixin(EntityBase):

--- a/tests/test_shutter.py
+++ b/tests/test_shutter.py
@@ -84,6 +84,12 @@ async def test_async_shutters(async_home):
             endpoint="api/setstate",
         )
 
+        assert await module.async_preferred_position()
+        mock_resp.assert_awaited_with(
+            params=gen_json_data(-2),
+            endpoint="api/setstate",
+        )
+
         assert await module.async_set_target_position(47)
         mock_resp.assert_awaited_with(
             params=gen_json_data(47),

--- a/tests/test_shutter.py
+++ b/tests/test_shutter.py
@@ -84,7 +84,7 @@ async def test_async_shutters(async_home):
             endpoint="api/setstate",
         )
 
-        assert await module.async_preferred_position()
+        assert await module.async_move_to_preferred_position()
         mock_resp.assert_awaited_with(
             params=gen_json_data(-2),
             endpoint="api/setstate",


### PR DESCRIPTION
Hello,

In the control APP, i have access to a "preferred position" for my shutter.
After some test and digging in the API, i noticed that there is an undocumented value of -2 for this.

Here is a small PR that add the functionnality.

i tested it in my setup and it's working well.
i modified the code, to be backward compatible (low value return -1 as before for example)

Feel free to ask if you need more screenshot or proof of the functionnality

Have a nice day !

FYI, it's the round icon at the right
![Screenshot_2024-05-23-10-18-48-78_d79490f7c2b38dc888dbc6c067ae1f9e](https://github.com/jabesq-org/pyatmo/assets/8221539/d6047005-b4d0-4de7-b5f5-b35835a9d562)
