### PR TITLE
catch camera url update timeout

### DIFF
--- a/src/pyatmo/modules/module.py
+++ b/src/pyatmo/modules/module.py
@@ -502,7 +502,7 @@ class CameraMixin(EntityBase):
                     self.local_url = await self._async_check_url(
                         temp_local_url,
                     )
-                except ClientConnectorError as exc:
+                except (TimeoutError, ClientConnectorError) as exc:
                     LOG.debug("Cannot connect to %s - reason: %s", temp_local_url, exc)
                     self.is_local = False
                     self.local_url = None


### PR DESCRIPTION
On my NOC module, I'm experiencing timeout for local url. It makes whole home update throw.

Client already catches connectivity error, but timeout wasn't part of them.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Catch timeout errors in the camera URL update process to improve error handling and prevent disruptions in the home update process.

Bug Fixes:
- Handle timeout errors when updating camera URLs to prevent the entire home update process from failing.

<!-- Generated by sourcery-ai[bot]: end summary -->