### PR TITLE
fix: NLIS module, remove the device_categroy type of the base module entity

### DIFF
--- a/src/pyatmo/modules/legrand.py
+++ b/src/pyatmo/modules/legrand.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from typing import TYPE_CHECKING
 
 from pyatmo.modules.module import (
     BatteryMixin,
@@ -13,6 +14,7 @@ from pyatmo.modules.module import (
     Fan,
     FirmwareMixin,
     Module,
+    ModuleT,
     OffloadMixin,
     PowerMixin,
     RemoteControlMixin,
@@ -21,6 +23,10 @@ from pyatmo.modules.module import (
     SwitchMixin,
     WifiMixin,
 )
+
+if TYPE_CHECKING:
+    from pyatmo.home import Home
+
 
 LOG = logging.getLogger(__name__)
 
@@ -73,12 +79,15 @@ class NLM(Switch):
 
 class NLIS(Switch):
     """Legrand double switch."""
+
     def __init__(self, home: Home, module: ModuleT) -> None:
+        """Initialize NLIS module."""
         super().__init__(home, module)
-        if not "#" in self.entity_id:
+        if "#" not in self.entity_id:
             # This is a workaround for the fact the this module type has three entries in the API
             # but one of them is not a light switch
             self.device_category = None
+
 
 class NLD(RemoteControlMixin, BatteryMixin):
     """Legrand Double On/Off dimmer remote. Wireless 2 button switch light."""

--- a/src/pyatmo/modules/legrand.py
+++ b/src/pyatmo/modules/legrand.py
@@ -73,7 +73,12 @@ class NLM(Switch):
 
 class NLIS(Switch):
     """Legrand double switch."""
-
+    def __init__(self, home: Home, module: ModuleT) -> None:
+        super().__init__(home, module)
+        if not "#" in self.entity_id:
+            # This is a workaround for the fact the this module type has three entries in the API
+            # but one of them is not a light switch
+            self.device_category = None
 
 class NLD(RemoteControlMixin, BatteryMixin):
     """Legrand Double On/Off dimmer remote. Wireless 2 button switch light."""

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -3,6 +3,8 @@
 import pytest
 
 from pyatmo import DeviceType
+from pyatmo.modules.device_types import DeviceCategory
+
 
 # pylint: disable=F6401
 
@@ -30,3 +32,15 @@ async def test_async_switch_NLF(async_home):  # pylint: disable=invalid-name
     assert module.on is False
     assert module.brightness == 63
     assert module.power == 0
+
+@pytest.mark.asyncio()
+async def test_async_switch_NLIS(async_home):  # pylint: disable=invalid-name
+    """Test NLIS Legrand module."""
+    module_id = "12:34:56:00:01:01:01:b6"
+    assert module_id in async_home.modules
+    module = async_home.modules[module_id]
+    assert module.device_category == None
+    module_id = "12:34:56:00:01:01:01:b6#1"
+    assert module_id in async_home.modules
+    module = async_home.modules[module_id]
+    assert module.device_category == DeviceCategory.switch

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -5,7 +5,6 @@ import pytest
 from pyatmo import DeviceType
 from pyatmo.modules.device_types import DeviceCategory
 
-
 # pylint: disable=F6401
 
 
@@ -33,13 +32,14 @@ async def test_async_switch_NLF(async_home):  # pylint: disable=invalid-name
     assert module.brightness == 63
     assert module.power == 0
 
+
 @pytest.mark.asyncio()
 async def test_async_switch_NLIS(async_home):  # pylint: disable=invalid-name
     """Test NLIS Legrand module."""
     module_id = "12:34:56:00:01:01:01:b6"
     assert module_id in async_home.modules
     module = async_home.modules[module_id]
-    assert module.device_category == None
+    assert module.device_category is None
     module_id = "12:34:56:00:01:01:01:b6#1"
     assert module_id in async_home.modules
     module = async_home.modules[module_id]

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -44,3 +44,7 @@ async def test_async_switch_NLIS(async_home):  # pylint: disable=invalid-name
     assert module_id in async_home.modules
     module = async_home.modules[module_id]
     assert module.device_category == DeviceCategory.switch
+    module_id = "12:34:56:00:01:01:01:b6#2"
+    assert module_id in async_home.modules
+    module = async_home.modules[module_id]
+    assert module.device_category == DeviceCategory.switch


### PR DESCRIPTION
The NLIS module is represented with 3 modules in the API:
- The module itself (id: "xx:yy:zz")
- The two contactors (ids: "xx:y:zz#A"

Only the contactors can be controlled.

## Summary by Sourcery

Update NLIS module handling to prevent assigning a device_category to the base module entity, reflecting that only contactors are controllable, and add corresponding tests.

Bug Fixes:
- Ensure only NLIS contactor modules are assigned a device_category, not the base module entity.

Tests:
- Add test to verify device_category assignment for NLIS modules and their contactors.