### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -9,6 +9,9 @@ on:
       - master
       - development
 
+permissions:
+  contents: read
+
 jobs:
   black:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/jabesq-org/pyatmo/security/code-scanning/7](https://github.com/jabesq-org/pyatmo/security/code-scanning/7)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will apply to all jobs in the workflow unless overridden by job-specific `permissions` blocks. Since the workflow primarily performs read-only operations (e.g., checking out code, installing dependencies, and running tests), we will set `contents: read` as the minimal required permission. This ensures that the `GITHUB_TOKEN` has only the necessary privileges.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

CI:
- Set contents: read permission at the workflow root to limit GITHUB_TOKEN privileges