### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -9,6 +9,9 @@ jobs:
   build-n-publish:
     name: Build and publish 📦 to TestPyPI
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Potential fix for [https://github.com/jabesq-org/pyatmo/security/code-scanning/2](https://github.com/jabesq-org/pyatmo/security/code-scanning/2)

To fix the issue, we will add a `permissions` block to the workflow. Since the workflow involves checking out the repository, setting up Python, installing dependencies, building a package, and publishing it to TestPyPI, we will assign the minimal permissions required for these actions. Specifically:
- `contents: read` is sufficient for reading the repository contents during the `actions/checkout` step.
- `packages: write` is required for publishing the package to TestPyPI.

The `permissions` block will be added at the job level (`build-n-publish`) to ensure it applies only to this specific job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Add a permissions block at the job level in the TestPyPI workflow to grant only the minimum required permissions (contents: read and packages: write), addressing a code scanning alert about missing permissions.

Bug Fixes:
- Fix code scanning alert by adding a permissions block to the TestPyPI workflow

CI:
- Grant contents: read and packages: write permissions to the build-and-publish job in .github/workflows/publish-to-test-pypi.yml