### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -5,10 +5,15 @@ on:
     tags:
       - "v*"
 
+permissions:
+  contents: read
+
 jobs:
   build-n-publish:
     name: Build and publish 📦 to PyPI
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Potential fix for [https://github.com/jabesq-org/pyatmo/security/code-scanning/1](https://github.com/jabesq-org/pyatmo/security/code-scanning/1)

To fix the issue, we will add a `permissions` block to the workflow. Since the workflow primarily interacts with the repository contents and publishes to PyPI, we will set `contents: read` at the workflow level and add `contents: write` specifically for the `build-n-publish` job. This ensures that the workflow has only the permissions it needs to perform its tasks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Grant explicit minimal GitHub Actions permissions to the publish-to-pypi workflow to resolve a code scanning alert

CI:
- Add workflow-level permissions: set contents:read for the publish-to-pypi workflow
- Add job-level permissions: set contents:write for the build-n-publish job