### PR TITLE
Improve packaging

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install setuptools wheel build
+          pip install build
       - name: Build a binary wheel and a source tarball
         run: >-
           python -m build .

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install setuptools wheel build
+          pip install build
       - name: Build a binary wheel and a source tarball
         run: >-
           python -m build .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [unreleased]
 
 ### Added
+- Added SPDX license identifier [PEP 639](https://peps.python.org/pep-0639/).
 
 ### Changed
 
 ### Fixed
+- Removed upper bound for Python version constraint.
 
 ### Removed
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,0 @@
-include README.md
-include LICENSE.txt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 build-backend = "setuptools.build_meta"
 requires = [
-    "setuptools>=64",
+    "setuptools>=77",
     "setuptools_scm>=8",
 ]
 
@@ -12,7 +12,6 @@ authors = [
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.11",
@@ -31,13 +30,15 @@ description = "Simple API to access Netatmo weather station data from any Python
 dynamic = [
     "version",
 ]
+license = "MIT"
+license-files = ["LICENSE.txt"]
 maintainers = [
     { email = "cgtobi@gmail.com", name = "Tobias Sauerwein" },
     { email = "jabesq@gmail.com", name = "Hugo Dupras" },
 ]
 name = "pyatmo"
 readme = "README.md"
-requires-python = ">=3.11,<3.14"
+requires-python = ">=3.11"
 
 [project.urls]
 Changelog = "https://github.com/jabesq-org/pyatmo/blob/development/CHANGELOG.md"
@@ -68,7 +69,6 @@ minversion = "8.0"
 [tool.ruff]
 fix = true
 line-length = 88
-target-version = "py312"
 
 [tool.ruff.lint]
 ignore = [

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,6 @@
 version = 1
 revision = 2
-requires-python = ">=3.11, <3.14"
+requires-python = ">=3.11"
 
 [[package]]
 name = "aiohappyeyeballs"


### PR DESCRIPTION
- Remove upper bound for Python version. This makes upgrading downstream packages quite difficult since they have to wait for a new release before upgrading themselves. The consensus in the Python community is that libraries should ideally only specific a lower bound.
- Add SPDX license identifier ([PEP 639](https://peps.python.org/pep-0639/)) and remove deprecated license classifier. This requires setuptools `>=77`.
https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license-and-license-files
- Remove `tool.ruff.target-version`. This is read from `project.requires-python` automatically.
- Remove `setuptools` and `wheel` dependencies. Setuptools is auto-installed during the isolated build.
- Remove redundant `MANIFEST.in` file. `README.md` and `LICENSE.txt` are already auto-included by setuptools.

Metadata diff
```diff
 ...
+License-Expression: MIT
 ...
-Classifier: License :: OSI Approved :: MIT License
 ...
-Requires-Python: <3.14,>=3.11
+Requires-Python: >=3.11
 ...
```