### PR TITLE
Add support for Legrand NLY three-phase energy meter (412175)

### DIFF
--- a/src/pyatmo/modules/__init__.py
+++ b/src/pyatmo/modules/__init__.py
@@ -53,6 +53,7 @@ from .legrand import (
     NLUO,
     NLUP,
     NLV,
+    NLY,
     Z3L,
     Z3V,
     NLunknown,

--- a/src/pyatmo/modules/__init__.py
+++ b/src/pyatmo/modules/__init__.py
@@ -145,6 +145,7 @@ __all__ = [
     "NLUO",
     "NLUP",
     "NLV",
+    "NLY",
     "NOC",
     "NPC",
     "NRV",

--- a/src/pyatmo/modules/device_types.py
+++ b/src/pyatmo/modules/device_types.py
@@ -76,6 +76,7 @@ class DeviceType(str, Enum):
     NLLF = "NLLF"  # Legrand Centralized Ventilation Control
     NLTS = "NLTS"  # Legrand motion sensor stub
     NLJ = "NLJ"  # Legrand garage door opener
+    NLY = "NLY"  # Connected 3 phases energy meter
 
     # BTicino Classe 300 EOS
     BNCX = "BNCX"  # internal panel = gateway

--- a/src/pyatmo/modules/legrand.py
+++ b/src/pyatmo/modules/legrand.py
@@ -181,3 +181,6 @@ class NLPD(OffloadMixin, Switch):
 
 class NLJ(FirmwareMixin, ShutterMixin, Module):
     """Legrand garage door opener."""
+
+class NLY(FirmwareMixin, EnergyHistoryMixin, PowerMixin, Module):
+       """Legrand connected 3 phases energy meter."""

--- a/src/pyatmo/modules/legrand.py
+++ b/src/pyatmo/modules/legrand.py
@@ -182,5 +182,6 @@ class NLPD(OffloadMixin, Switch):
 class NLJ(FirmwareMixin, ShutterMixin, Module):
     """Legrand garage door opener."""
 
+
 class NLY(FirmwareMixin, EnergyHistoryMixin, PowerMixin, Module):
-       """Legrand connected 3 phases energy meter."""
+    """Legrand connected 3 phases energy meter."""


### PR DESCRIPTION
## Description
Adds support for Legrand NLY three-phase connected energy meter (model 412175).
   
## Changes
- Added NLY device type to device_types.py
- Created NLY device class in legrand.py with FirmwareMixin, EnergyHistoryMixin, and PowerMixin
- Exported NLY class in modules/__init__.py
   
## Testing
Tested with Legrand 412175 three-phase energy meter connected via Legrand Home Gateway.
Device appears in Home Assistant and reports energy data correctly.
   
Implementation based on testing by multiple users with the actual hardware.
   
## Related Issues
- home-assistant/core#128575
   
## Credit
@osmaterdca suggested these changes on the home-assistant/core issue referenced above ( https://github.com/home-assistant/core/issues/128575#issuecomment-3298262909)

## Summary by Sourcery

New Features:
- Add support for Legrand NLY three-phase energy meter (model 412175)