### PR TITLE
feat: enhance weather attribute normalization to support wind gust data across all API endpoints

### DIFF
--- a/src/pyatmo/account.py
+++ b/src/pyatmo/account.py
@@ -18,7 +18,7 @@ from pyatmo.const import (
     SETSTATE_ENDPOINT,
     RawData,
 )
-from pyatmo.helpers import extract_raw_data
+from pyatmo.helpers import extract_raw_data, normalize_weather_attributes
 from pyatmo.home import Home
 from pyatmo.modules.module import Energy, MeasureInterval, Module
 
@@ -293,33 +293,3 @@ class AsyncAccount:
             ),
             None,
         )
-
-
-ATTRIBUTES_TO_FIX: dict[str, str] = {
-    "_id": "id",
-    "firmware": "firmware_revision",
-    "wifi_status": "wifi_strength",
-    "rf_status": "rf_strength",
-    "Temperature": "temperature",
-    "Humidity": "humidity",
-    "Pressure": "pressure",
-    "CO2": "co2",
-    "AbsolutePressure": "absolute_pressure",
-    "Noise": "noise",
-    "Rain": "rain",
-    "WindStrength": "wind_strength",
-    "WindAngle": "wind_angle",
-    "GustStrength": "gust_strength",
-    "GustAngle": "gust_angle",
-}
-
-
-def normalize_weather_attributes(raw_data: RawData) -> dict[str, Any]:
-    """Normalize weather attributes."""
-    result: dict[str, Any] = {}
-    for attribute, value in raw_data.items():
-        if attribute == "dashboard_data":
-            result.update(**normalize_weather_attributes(value))
-        else:
-            result[ATTRIBUTES_TO_FIX.get(attribute, attribute)] = value
-    return result

--- a/src/pyatmo/account.py
+++ b/src/pyatmo/account.py
@@ -18,7 +18,7 @@ from pyatmo.const import (
     SETSTATE_ENDPOINT,
     RawData,
 )
-from pyatmo.helpers import extract_raw_data, normalize_weather_attributes
+from pyatmo.helpers import extract_raw_data
 from pyatmo.home import Home
 from pyatmo.modules.module import Energy, MeasureInterval, Module
 
@@ -235,8 +235,8 @@ class AsyncAccount:
                         module_data["home_id"] = home_id
                         module_data["id"] = module_data["_id"]
                         module_data["name"] = module_data.get("module_name")
-                        modules_data.append(normalize_weather_attributes(module_data))
-                    modules_data.append(normalize_weather_attributes(device_data))
+                        modules_data.append(module_data)
+                    modules_data.append(device_data)
 
                     self.homes[home_id] = Home(
                         self.auth,
@@ -247,7 +247,7 @@ class AsyncAccount:
                         },
                     )
                 await self.homes[home_id].update(
-                    {HOME: {"modules": [normalize_weather_attributes(device_data)]}},
+                    {HOME: {"modules": [device_data]}},
                 )
             else:
                 LOG.debug("No home %s (%s) found.", home_id, home_id)
@@ -264,7 +264,6 @@ class AsyncAccount:
                     "station_name",
                     device_data.get("module_name", "Unknown"),
                 )
-                device_data = normalize_weather_attributes(device_data)
                 if device_data["id"] not in self.modules:
                     self.modules[device_data["id"]] = getattr(
                         modules,

--- a/src/pyatmo/helpers.py
+++ b/src/pyatmo/helpers.py
@@ -17,8 +17,6 @@ NormalizableData = dict[str, Any] | list[Any] | str | int | float | bool | None
 
 ATTRIBUTES_TO_FIX: dict[str, str] = {
     "firmware": "firmware_revision",
-    "firmware_revision": "firmware_revision",
-    "firmware_name": "firmware_name",
     "wifi_status": "wifi_strength",
     "rf_status": "rf_strength",
     "Temperature": "temperature",

--- a/src/pyatmo/helpers.py
+++ b/src/pyatmo/helpers.py
@@ -12,6 +12,9 @@ if TYPE_CHECKING:
 
 LOG: logging.Logger = logging.getLogger(__name__)
 
+# types for data that can be normalized (recursive structures) - to satisfy mypy
+NormalizableData = dict[str, Any] | list[Any] | str | int | float | bool | None
+
 ATTRIBUTES_TO_FIX: dict[str, str] = {
     "firmware": "firmware_revision",
     "firmware_revision": "firmware_revision",
@@ -34,26 +37,28 @@ ATTRIBUTES_TO_FIX: dict[str, str] = {
 }
 
 
-def normalize_weather_attributes(raw_data: RawData) -> RawData:
+def normalize_weather_attributes(raw_data: NormalizableData) -> NormalizableData:
     """Normalize weather-related attributes recursively."""
 
+    if isinstance(raw_data, list):
+        return [normalize_weather_attributes(item) for item in raw_data]
+
     if not isinstance(raw_data, dict):
-        return (
-            [normalize_weather_attributes(item) for item in raw_data]
-            if isinstance(raw_data, list)
-            else raw_data
-        )
+        return raw_data
+
     normalized: dict[str, Any] = {}
     for key, value in raw_data.items():
         if key == "_id":
             normalized["_id"] = value
             continue
         if key == "dashboard_data" and isinstance(value, dict):
-            normalized |= normalize_weather_attributes(value)
+            # useless cast here to satisfy mypy
+            normalized |= cast("dict[str, Any]", normalize_weather_attributes(value))
             continue
-        normalized[ATTRIBUTES_TO_FIX.get(key, key)] = normalize_weather_attributes(
-            value
-        )
+
+        mapped_key = ATTRIBUTES_TO_FIX[key] if key in ATTRIBUTES_TO_FIX else key  # noqa: SIM401
+        normalized[mapped_key] = normalize_weather_attributes(value)
+
     if "_id" in normalized and "id" not in normalized:
         normalized["id"] = normalized["_id"]
     return normalized
@@ -89,10 +94,11 @@ def extract_raw_data(resp: RawData, tag: str) -> RawData:
         msg = "No device found, errors in response"
         raise NoDeviceError(msg)
 
-    body = normalize_weather_attributes(resp["body"])
+    # useless cast here again to satisfy mypy
+    body = cast("dict[str, Any]", normalize_weather_attributes(resp["body"]))
 
     if tag == "homes":
-        homes: list[dict[str, Any] | str] = fix_id(body.get(tag))
+        homes: list[dict[str, Any] | str] = fix_id(body.get(tag, []))
         if not homes:
             LOG.debug("Server response (tag: %s): %s", tag, resp)
             msg = "No homes found"
@@ -102,7 +108,7 @@ def extract_raw_data(resp: RawData, tag: str) -> RawData:
             "errors": body.get("errors", []),
         }
 
-    if not (raw_data := fix_id(body.get(tag))):
+    if not (raw_data := fix_id(body.get(tag, []))):
         LOG.debug("Server response (tag: %s): %s", tag, resp)
         msg = "No device data available"
         raise NoDeviceError(msg)

--- a/src/pyatmo/helpers.py
+++ b/src/pyatmo/helpers.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any, cast
 
-from pyatmo.const import HOME
 from pyatmo.exceptions import NoDeviceError
 
 if TYPE_CHECKING:
@@ -14,7 +13,6 @@ if TYPE_CHECKING:
 LOG: logging.Logger = logging.getLogger(__name__)
 
 ATTRIBUTES_TO_FIX: dict[str, str] = {
-    "_id": "id",
     "firmware": "firmware_revision",
     "firmware_revision": "firmware_revision",
     "firmware_name": "firmware_name",
@@ -39,29 +37,29 @@ ATTRIBUTES_TO_FIX: dict[str, str] = {
 def normalize_weather_attributes(raw_data: RawData) -> RawData:
     """Normalize weather-related attributes recursively."""
 
-    if isinstance(raw_data, dict):
-        normalized: dict[str, Any] = {}
-        has_internal_id = "_id" in raw_data
-        for key, value in raw_data.items():
-            if key == "_id":
-                normalized["_id"] = value
-                if "id" not in raw_data:
-                    normalized.setdefault("id", value)
-                continue
-            if key == "dashboard_data" and isinstance(value, dict):
-                normalized.update(normalize_weather_attributes(value))
-                continue
-            normalized[ATTRIBUTES_TO_FIX.get(key, key)] = normalize_weather_attributes(
-                value
-            )
-        if has_internal_id and "id" not in normalized:
-            normalized["id"] = raw_data["_id"]
-        return normalized
-
-    if isinstance(raw_data, list):
-        return [normalize_weather_attributes(item) for item in raw_data]
-
-    return raw_data
+    if not isinstance(raw_data, dict):
+        return (
+            [normalize_weather_attributes(item) for item in raw_data]
+            if isinstance(raw_data, list)
+            else raw_data
+        )
+    normalized: dict[str, Any] = {}
+    has_internal_id = "_id" in raw_data
+    for key, value in raw_data.items():
+        if key == "_id":
+            normalized["_id"] = value
+            if "id" not in raw_data:
+                normalized.setdefault("id", value)
+            continue
+        if key == "dashboard_data" and isinstance(value, dict):
+            normalized |= normalize_weather_attributes(value)
+            continue
+        normalized[ATTRIBUTES_TO_FIX.get(key, key)] = normalize_weather_attributes(
+            value
+        )
+    if has_internal_id and "id" not in normalized:
+        normalized["id"] = raw_data["_id"]
+    return normalized
 
 
 def fix_id(raw_data: list[RawData | str]) -> list[RawData | str]:
@@ -87,7 +85,7 @@ def fix_id(raw_data: list[RawData | str]) -> list[RawData | str]:
 def extract_raw_data(resp: RawData, tag: str) -> RawData:
     """Extract raw data from server response."""
     if tag == "body":
-        return {"public": normalize_weather_attributes(resp["body"]), "errors": []}
+        return {"public": resp["body"], "errors": []}
 
     if resp is None or "body" not in resp or tag not in resp["body"]:
         LOG.debug("Server response (tag: %s): %s", tag, resp)
@@ -95,10 +93,6 @@ def extract_raw_data(resp: RawData, tag: str) -> RawData:
         raise NoDeviceError(msg)
 
     body = normalize_weather_attributes(resp["body"])
-    if tag == HOME and "modules" in body.get(HOME, {}):
-        body[HOME]["modules"] = [
-            normalize_weather_attributes(module) for module in body[HOME]["modules"]
-        ]
 
     if tag == "homes":
         homes: list[dict[str, Any] | str] = fix_id(body.get(tag))

--- a/src/pyatmo/helpers.py
+++ b/src/pyatmo/helpers.py
@@ -5,12 +5,63 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any, cast
 
+from pyatmo.const import HOME
 from pyatmo.exceptions import NoDeviceError
 
 if TYPE_CHECKING:
     from pyatmo.const import RawData
 
 LOG: logging.Logger = logging.getLogger(__name__)
+
+ATTRIBUTES_TO_FIX: dict[str, str] = {
+    "_id": "id",
+    "firmware": "firmware_revision",
+    "firmware_revision": "firmware_revision",
+    "firmware_name": "firmware_name",
+    "wifi_status": "wifi_strength",
+    "rf_status": "rf_strength",
+    "Temperature": "temperature",
+    "Humidity": "humidity",
+    "Pressure": "pressure",
+    "CO2": "co2",
+    "AbsolutePressure": "absolute_pressure",
+    "Noise": "noise",
+    "Rain": "rain",
+    "WindStrength": "wind_strength",
+    "WindAngle": "wind_angle",
+    "GustStrength": "gust_strength",
+    "GustAngle": "gust_angle",
+    "wind_gust": "gust_strength",
+    "wind_gust_angle": "gust_angle",
+}
+
+
+def normalize_weather_attributes(raw_data: RawData) -> RawData:
+    """Normalize weather-related attributes recursively."""
+
+    if isinstance(raw_data, dict):
+        normalized: dict[str, Any] = {}
+        has_internal_id = "_id" in raw_data
+        for key, value in raw_data.items():
+            if key == "_id":
+                normalized["_id"] = value
+                if "id" not in raw_data:
+                    normalized.setdefault("id", value)
+                continue
+            if key == "dashboard_data" and isinstance(value, dict):
+                normalized.update(normalize_weather_attributes(value))
+                continue
+            normalized[ATTRIBUTES_TO_FIX.get(key, key)] = normalize_weather_attributes(
+                value
+            )
+        if has_internal_id and "id" not in normalized:
+            normalized["id"] = raw_data["_id"]
+        return normalized
+
+    if isinstance(raw_data, list):
+        return [normalize_weather_attributes(item) for item in raw_data]
+
+    return raw_data
 
 
 def fix_id(raw_data: list[RawData | str]) -> list[RawData | str]:
@@ -36,27 +87,33 @@ def fix_id(raw_data: list[RawData | str]) -> list[RawData | str]:
 def extract_raw_data(resp: RawData, tag: str) -> RawData:
     """Extract raw data from server response."""
     if tag == "body":
-        return {"public": resp["body"], "errors": []}
+        return {"public": normalize_weather_attributes(resp["body"]), "errors": []}
 
     if resp is None or "body" not in resp or tag not in resp["body"]:
         LOG.debug("Server response (tag: %s): %s", tag, resp)
         msg = "No device found, errors in response"
         raise NoDeviceError(msg)
 
+    body = normalize_weather_attributes(resp["body"])
+    if tag == HOME and "modules" in body.get(HOME, {}):
+        body[HOME]["modules"] = [
+            normalize_weather_attributes(module) for module in body[HOME]["modules"]
+        ]
+
     if tag == "homes":
-        homes: list[dict[str, Any] | str] = fix_id(resp["body"].get(tag))
+        homes: list[dict[str, Any] | str] = fix_id(body.get(tag))
         if not homes:
             LOG.debug("Server response (tag: %s): %s", tag, resp)
             msg = "No homes found"
             raise NoDeviceError(msg)
         return {
             tag: homes,
-            "errors": resp["body"].get("errors", []),
+            "errors": body.get("errors", []),
         }
 
-    if not (raw_data := fix_id(resp["body"].get(tag))):
+    if not (raw_data := fix_id(body.get(tag))):
         LOG.debug("Server response (tag: %s): %s", tag, resp)
         msg = "No device data available"
         raise NoDeviceError(msg)
 
-    return {tag: raw_data, "errors": resp["body"].get("errors", [])}
+    return {tag: raw_data, "errors": body.get("errors", [])}

--- a/src/pyatmo/helpers.py
+++ b/src/pyatmo/helpers.py
@@ -44,12 +44,9 @@ def normalize_weather_attributes(raw_data: RawData) -> RawData:
             else raw_data
         )
     normalized: dict[str, Any] = {}
-    has_internal_id = "_id" in raw_data
     for key, value in raw_data.items():
         if key == "_id":
             normalized["_id"] = value
-            if "id" not in raw_data:
-                normalized.setdefault("id", value)
             continue
         if key == "dashboard_data" and isinstance(value, dict):
             normalized |= normalize_weather_attributes(value)
@@ -57,8 +54,8 @@ def normalize_weather_attributes(raw_data: RawData) -> RawData:
         normalized[ATTRIBUTES_TO_FIX.get(key, key)] = normalize_weather_attributes(
             value
         )
-    if has_internal_id and "id" not in normalized:
-        normalized["id"] = raw_data["_id"]
+    if "_id" in normalized and "id" not in normalized:
+        normalized["id"] = normalized["_id"]
     return normalized
 
 

--- a/src/pyatmo/home.py
+++ b/src/pyatmo/home.py
@@ -25,6 +25,7 @@ from pyatmo.exceptions import (
     InvalidStateError,
     NoScheduleError,
 )
+from pyatmo.helpers import normalize_weather_attributes
 from pyatmo.person import Person
 from pyatmo.room import Room
 from pyatmo.schedule import Schedule
@@ -174,6 +175,7 @@ class Home:
 
         has_an_update = False
         for module in data.get("modules", []):
+            module = normalize_weather_attributes(module)
             has_an_update = True
             if module["id"] not in self.modules:
                 self.update_topology({"modules": [module]})

--- a/src/pyatmo/home.py
+++ b/src/pyatmo/home.py
@@ -25,7 +25,6 @@ from pyatmo.exceptions import (
     InvalidStateError,
     NoScheduleError,
 )
-from pyatmo.helpers import normalize_weather_attributes
 from pyatmo.person import Person
 from pyatmo.room import Room
 from pyatmo.schedule import Schedule
@@ -175,7 +174,6 @@ class Home:
 
         has_an_update = False
         for module in data.get("modules", []):
-            module = normalize_weather_attributes(module)
             has_an_update = True
             if module["id"] not in self.modules:
                 self.update_topology({"modules": [module]})


### PR DESCRIPTION
## Context
For context, I'm working on a PR on the `ha-core` repository (Home Assistant), on the Netatmo component. The initial issue was that retrieving weather infos with `/getstationdata` is not responsive enough, since data is aggregated every 10mn. However, the `/homestatus` endpoint gives almost live data (according to Netatmo).

So I made modifications in `ha-core`, everything was working except for the gust attributes. The reason? The names of the attributes are different with the `/homestatus` route : 

```json
        "wind_gust": 3,
        "wind_gust_angle": 180
```

## Main changes
1. **Refactored `normalize_weather_attributes()`** :
I moved from `account.py` to `helpers.py` for a better code organization.
Enhanced it to work recursively with the nested dictionaries and lists

2. **Added support for additional attributes in the mapping**
Added support for the wind_gust attributes, so the mapping works like it should be with the `/homestatus` endpoint

3. **Applied normalization across all data retrieval paths**
Applied the normalization process to all responses types. For the HOME endpoint, I made sure modules within home data are normalized.

The tests are passing. And of course, it fixes my issue : wind_gust, and wind_gust_angle are retrieved and updated every time I use the `/homestatus` endpoint.

@cgtobi : I tried to reach you on Discord to have your opinion about the way I'd like to implement this on Home Assistant. Basically, it's just using the homestatus endpoint, but I'd like to directly talk about it with you.

Thanks guys! Have a great day :)

## Summary by Sourcery

Normalize Netatmo weather data consistently across responses and extend support for wind gust attributes.

New Features:
- Support wind gust and wind gust angle attributes in weather data normalization, including homestatus responses.

Enhancements:
- Move and enhance weather attribute normalization into helpers as a recursive utility applied to nested dictionaries and lists.
- Apply attribute normalization to all extracted response bodies before further processing, ensuring consistent field names like firmware, signal strengths, and core sensor metrics.