### PR TITLE
feat: add WebRTC live stream support for Netatmo Indoor Camera Advance (NPC)  

### DIFF
--- a/fixtures/webrtc_offer_ok.json
+++ b/fixtures/webrtc_offer_ok.json
@@ -1,0 +1,13 @@
+{
+    "status": "ok",
+    "time_server": 1765234648,
+    "body": {
+        "type": "ack",
+        "time_server": 1765234642,
+        "correlation_id": "2775454822782367811",
+        "session_id": "af6da83b-1fd5-46ab-bf08-8e5db3cb9725",
+        "tag_id": "OZzgKVlQCW0=",
+        "status": "ok",
+        "sdpAnswer": "sdp_test_answser"
+    }
+}

--- a/fixtures/webrtc_offer_unreachable.json
+++ b/fixtures/webrtc_offer_unreachable.json
@@ -1,0 +1,14 @@
+{
+    "status": "ok",
+    "time_server": 1765234880,
+    "body": {
+        "type": "ack",
+        "time_server": 1765234880,
+        "correlation_id": "5792380006970076896",
+        "status": "error",
+        "error": {
+            "code": 41,
+            "message": "Device is unreachable"
+        }
+    }
+}

--- a/fixtures/webrtc_terminate_no_session.json
+++ b/fixtures/webrtc_terminate_no_session.json
@@ -1,0 +1,14 @@
+{
+    "status": "ok",
+    "time_server": 1765234777,
+    "body": {
+        "type": "ack",
+        "time_server": 1765234776,
+        "correlation_id": "9204136935571038154",
+        "status": "error",
+        "error": {
+            "code": 21,
+            "message": "Nil session"
+        }
+    }
+}

--- a/fixtures/webrtc_terminate_ok.json
+++ b/fixtures/webrtc_terminate_ok.json
@@ -1,0 +1,10 @@
+{
+    "status": "ok",
+    "time_server": 1765234822,
+    "body": {
+        "type": "ack",
+        "time_server": 1765234822,
+        "correlation_id": "11591074238736810245",
+        "status": "ok"
+    }
+}

--- a/src/pyatmo/__init__.py
+++ b/src/pyatmo/__init__.py
@@ -17,6 +17,7 @@ from pyatmo.home import Home
 from pyatmo.modules import Module
 from pyatmo.modules.device_types import DeviceType
 from pyatmo.room import Room
+from pyatmo.webrtc import WebRTCStream
 
 __all__: list[str] = [
     "AbstractAsyncAuth",
@@ -33,6 +34,7 @@ __all__: list[str] = [
     "NoDeviceError",
     "NoScheduleError",
     "Room",
+    "WebRTCStream",
     "const",
     "modules",
 ]

--- a/src/pyatmo/const.py
+++ b/src/pyatmo/const.py
@@ -59,6 +59,7 @@ ALL_SCOPES: list[str] = [
     "access_camera",  # Netatmo camera products
     "access_doorbell",  # Netatmo Smart Video Doorbell
     "access_presence",  # Netatmo Smart Outdoor Camera
+    "access_camerapro",  # Netatmo Indoor Camera Advance
     "read_bubendorff",  # Bubbendorf shutters
     "read_bfi",  # BTicino IP
     "read_camera",  # Netatmo camera products
@@ -73,6 +74,7 @@ ALL_SCOPES: list[str] = [
     "read_smokedetector",  # Smart Smoke Alarm information and events
     "read_station",  # Netatmo weather station
     "read_thermostat",  # Netatmo climate products
+    "read_camerapro",  # Netatmo Indoor Camera Advance
     "write_bubendorff",  # Bubbendorf shutters
     "write_bfi",  # BTicino IP
     "write_camera",  # Netatmo camera products
@@ -82,6 +84,7 @@ ALL_SCOPES: list[str] = [
     "write_presence",  # Netatmo Smart Outdoor Camera
     "write_smarther",  # Smarther products
     "write_thermostat",  # Netatmo climate products
+    "write_camerapro",  # Netatmo Indoor Camera Advance
 ]
 
 EVENTS = "events"

--- a/src/pyatmo/const.py
+++ b/src/pyatmo/const.py
@@ -49,6 +49,9 @@ GETSTATIONDATA_ENDPOINT = "api/getstationsdata"
 
 GETPUBLIC_DATA_ENDPOINT = "api/getpublicdata"
 
+WEBRTC_OFFER_ENDPOINT = "api/webrtc/offer"
+WEBRTC_TERMINATE_ENDPOINT = "api/webrtc/terminate"
+
 AUTHORIZATION_HEADER = "Authorization"
 
 # Possible scops

--- a/src/pyatmo/modules/module.py
+++ b/src/pyatmo/modules/module.py
@@ -11,7 +11,12 @@ from typing import TYPE_CHECKING, Any
 
 from aiohttp import ClientConnectorError, ClientResponse
 
-from pyatmo.const import GETMEASURE_ENDPOINT, RawData
+from pyatmo.const import (
+    GETMEASURE_ENDPOINT,
+    WEBRTC_OFFER_ENDPOINT,
+    WEBRTC_TERMINATE_ENDPOINT,
+    RawData,
+)
 from pyatmo.exceptions import ApiError
 from pyatmo.modules.base_class import EntityBase, NetatmoBase, Place, update_name
 from pyatmo.modules.device_types import (
@@ -21,6 +26,7 @@ from pyatmo.modules.device_types import (
     DeviceType,
     DoorTagCategory,
 )
+from pyatmo.webrtc import WebRTCAnswer, WebRTCStream
 
 if TYPE_CHECKING:
     from pyatmo.event import Event
@@ -490,8 +496,8 @@ class ShutterMixin(EntityBase):
         return await self.async_set_target_position(self.__preferred_position)
 
 
-class CameraMixin(EntityBase):
-    """Mixin for camera data."""
+class CameraMixinBase(EntityBase):
+    """Base class for camera mixins."""
 
     def __init__(self, home: Home, module: ModuleT) -> None:
         """Initialize camera mixin."""
@@ -504,13 +510,28 @@ class CameraMixin(EntityBase):
         self.alim_status: int | None = None
         self.device_type: DeviceType
 
+        self._force_vpn_url = False
+
+    @property
+    def camera_url(self) -> str | None:
+        """Return the camera URL, if available.
+
+        Depending on the camera streaming protocol, this URL can be used to retrieve:
+          - The live snapshot (HLS and WebRTC).
+          - The live stream (HLS only).
+        """
+        return self.local_url or self.vpn_url
+
     async def async_get_live_snapshot(self) -> bytes | None:
         """Fetch live camera image."""
 
-        if not self.local_url and not self.vpn_url:
+        url = self.camera_url
+
+        if not url:
             return None
+
         resp = await self.home.auth.async_get_image(
-            base_url=f"{self.local_url or self.vpn_url}",
+            base_url=f"{url}",
             endpoint="/live/snapshot_720.jpg",
         )
 
@@ -519,8 +540,9 @@ class CameraMixin(EntityBase):
     async def async_update_camera_urls(self) -> None:
         """Update and validate the camera urls."""
 
-        if self.device_type == "NDB":
-            self.is_local = None
+        if self._force_vpn_url:
+            self.local_url = None
+            return
 
         if self.vpn_url and self.is_local:
             temp_local_url = await self._async_check_url(self.vpn_url)
@@ -553,6 +575,96 @@ class CameraMixin(EntityBase):
 
         resp_data = await resp.json()
         return resp_data.get("local_url") if resp_data else None
+
+
+class HLSCameraMixin(CameraMixinBase):
+    """Mixin for cameras using the HLS protocol."""
+
+
+class WebRTCCameraMixin(CameraMixinBase):
+    """Mixin for cameras using the WebRTC protocol."""
+
+    def __init__(self, home: Home, module: ModuleT) -> None:
+        """Initialize WebRTC camera mixin."""
+
+        super().__init__(home, module)
+
+        # WebRTC cameras don't support accessing the live stream nor snapshot via the local URL
+        self._force_vpn_url = True
+
+    async def async_start_stream(self, session_id: str, sdp_offer: str) -> WebRTCAnswer:
+        """Start WebRTC streaming session.
+
+        Netatmo cameras do not support ICE trickle when accessed through third-party applications,
+        so the SDP offer must include all ICE candidates.
+        """
+
+        params = {
+            "home_id": self.home.entity_id,
+            "device_id": self.entity_id,
+            "sdp": sdp_offer,
+            "session_id": session_id,
+        }
+
+        resp = await self.home.auth.async_post_api_request(
+            endpoint=WEBRTC_OFFER_ENDPOINT, params=params
+        )
+
+        json_resp = await resp.json()
+        resp_body = self._parse_webrtc_response_body(json_resp)
+
+        try:
+            if session_id != resp_body["session_id"]:
+                msg = "Invalid WebRTC answer: session ID mismatch"
+                raise ApiError(msg)
+
+            tag_id = resp_body["tag_id"]
+            sdp_answer = resp_body["sdpAnswer"]
+        except KeyError as exc:
+            msg = f"Invalid WebRTC answer: missing {exc} field"
+            raise ApiError(msg) from exc
+
+        return WebRTCAnswer(WebRTCStream(session_id, tag_id), sdp_answer)
+
+    async def async_stop_stream(self, stream: WebRTCStream) -> None:
+        """Stop an active WebRTC streaming session."""
+
+        params = {
+            "home_id": self.home.entity_id,
+            "device_id": self.entity_id,
+            "session_id": stream.session_id,
+            "tag_id": stream.tag_id,
+        }
+
+        resp = await self.home.auth.async_post_api_request(
+            endpoint=WEBRTC_TERMINATE_ENDPOINT, params=params
+        )
+
+        json_resp = await resp.json()
+        self._parse_webrtc_response_body(json_resp)
+
+    def _parse_webrtc_response_body(self, json_resp: dict[str, Any]) -> dict[str, Any]:
+        """Extract the body from a WebRTC API response and check for errors."""
+
+        if not json_resp:
+            msg = "Empty WebRTC response"
+            raise ApiError(msg)
+
+        try:
+            resp_body = json_resp["body"]
+
+            if resp_body["status"] != "ok":
+                error_dict = resp_body["error"]
+                error_code = error_dict["code"]
+                error_msg = error_dict["message"]
+
+                msg = f"WebRTC API error: {error_msg} ({error_code})"
+                raise ApiError(msg)
+        except KeyError as exc:
+            msg = f"Invalid WebRTC response: missing {exc} field"
+            raise ApiError(msg) from exc
+
+        return resp_body
 
 
 class FloodlightMixin(EntityBase):
@@ -1194,7 +1306,7 @@ class Camera(
     FirmwareMixin,
     MonitoringMixin,
     EventMixin,
-    CameraMixin,
+    CameraMixinBase,
     WifiMixin,
     Module,
 ):

--- a/src/pyatmo/modules/netatmo.py
+++ b/src/pyatmo/modules/netatmo.py
@@ -28,6 +28,7 @@ from pyatmo.modules.module import (
     FirmwareMixin,
     FloodlightMixin,
     HealthIndexMixin,
+    HLSCameraMixin,
     HumidityMixin,
     Module,
     MonitoringMixin,
@@ -39,6 +40,7 @@ from pyatmo.modules.module import (
     SirenMixin,
     StatusMixin,
     TemperatureMixin,
+    WebRTCCameraMixin,
     WifiMixin,
     WindMixin,
 )
@@ -70,19 +72,19 @@ class OTM(FirmwareMixin, RfMixin, BatteryMixin, BoilerMixin, Module):
     """Class to represent a Netatmo OTM."""
 
 
-class NACamera(Camera):
+class NACamera(HLSCameraMixin, Camera):
     """Class to represent a Netatmo NACamera."""
 
 
-class NPC(Camera):
+class NPC(WebRTCCameraMixin, Camera):
     """Class to represent a Netatmo NPC."""
 
 
-class NOC(SirenMixin, FloodlightMixin, Camera):
+class NOC(SirenMixin, FloodlightMixin, HLSCameraMixin, Camera):
     """Class to represent a Netatmo NOC."""
 
 
-class NDB(Camera):
+class NDB(WebRTCCameraMixin, Camera):
     """Class to represent a Netatmo NDB."""
 
 

--- a/src/pyatmo/webrtc.py
+++ b/src/pyatmo/webrtc.py
@@ -1,0 +1,19 @@
+"""WebRTC-related definitions."""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class WebRTCStream:
+    """A WebRTC stream."""
+
+    session_id: str
+    tag_id: str
+
+
+@dataclass
+class WebRTCAnswer:
+    """A WebRTC answer from the Netatmo API."""
+
+    stream: WebRTCStream
+    sdp: str

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -4,9 +4,11 @@ import json
 from unittest.mock import AsyncMock, patch
 
 import anyio
+import pytest
 
-from pyatmo import DeviceType
+from pyatmo import ApiError, DeviceType, WebRTCStream
 from tests.common import MockResponse
+from tests.conftest import does_not_raise
 
 
 async def test_async_camera_NACamera(async_home):
@@ -18,6 +20,9 @@ async def test_async_camera_NACamera(async_home):
     assert module.device_type == DeviceType.NACamera
     assert module.is_local
     assert module.local_url == "http://192.168.0.123/678460a0d47e5618699fb31169e2b47d"
+    vpn_url = "https://prodvpn-eu-2.netatmo.net/restricted/10.255.123.45/609e27de5699fb18147ab47d06846631/MTRPn_BeWCav5RBq4U1OMDruTW4dkQ0NuMwNDAw11g,,"
+    assert module.vpn_url == vpn_url
+    assert module.camera_url == module.local_url
     person_id = "91827374-7e04-5298-83ad-a0cb8372dff1"
     assert person_id in module.home.persons
     person = module.home.persons[person_id]
@@ -34,7 +39,10 @@ async def test_async_camera_NPC(async_home):
     await module.async_update_camera_urls()
     assert module.device_type == DeviceType.NPC
     assert module.is_local
-    assert module.local_url == "http://192.168.0.123/678460a0d47e5618699fb31169e2b47d"
+    assert module.local_url is None
+    vpn_url = "https://prodvpn-eu-2.netatmo.net/restricted/10.255.123.45/9fb1814609e27de5697ab47d06846631/MTRPn_BeWCav5RBq4U1OMDruTW4dkQ0NuMwNDAw11g,,"
+    assert module.vpn_url == vpn_url
+    assert module.camera_url == module.vpn_url
     person_id = "91827374-7e04-5298-83ad-a0cb8372dff1"
     assert person_id in module.home.persons
     person = module.home.persons[person_id]
@@ -54,6 +62,10 @@ async def test_async_NOC(async_home):
     assert module.monitoring is True
     assert module.alim_status == 2
     assert module.is_local is False
+    assert module.local_url is None
+    vpn_url = "https://prodvpn-eu-6.netatmo.net/10.20.30.41/333333333333/444444444444,,"
+    assert module.vpn_url == vpn_url
+    assert module.camera_url == module.vpn_url
     assert module.floodlight == "auto"
     assert module.siren_status == "no_sound"
 
@@ -201,3 +213,131 @@ async def test_async_camera_siren_missing_status(async_home):
     # Simulate an API response without siren_status (e.g. older firmware)
     module.siren_status = None
     assert module.siren_status is None
+
+
+@pytest.mark.parametrize(
+    ("module_id", "device_type", "can_use_local_url"),
+    [
+        ("12:34:56:00:f1:62", DeviceType.NACamera, True),
+        ("12:34:56:10:b9:0e", DeviceType.NOC, True),
+        ("12:34:56:00:f1:63", DeviceType.NPC, False),
+    ],
+)
+async def test_async_live_snapshot(
+    async_home, module_id, device_type, can_use_local_url
+):
+    assert module_id in async_home.modules
+    module = async_home.modules[module_id]
+    assert module.device_type == device_type
+    await module.async_update_camera_urls()
+    assert module.local_url or module.vpn_url
+
+    expected_snapshot = b"test stream image bytes"
+
+    with patch(
+        "pyatmo.auth.AbstractAsyncAuth.async_get_image",
+        AsyncMock(return_value=expected_snapshot),
+    ) as mock_resp:
+        received_snapshot = await module.async_get_live_snapshot()
+
+        if can_use_local_url and module.is_local:
+            base_url = module.local_url
+        else:
+            base_url = module.vpn_url
+
+        mock_resp.assert_awaited_with(
+            base_url=base_url,
+            endpoint="/live/snapshot_720.jpg",
+        )
+
+        assert received_snapshot == expected_snapshot
+
+
+@pytest.mark.parametrize(
+    ("response_fixture", "exception"),
+    [
+        ("webrtc_offer_ok.json", does_not_raise()),
+        ("webrtc_offer_unreachable.json", pytest.raises(ApiError)),
+    ],
+)
+async def test_async_webrtc_stream_start(async_home, response_fixture, exception):
+    """Test starting a WebRTC stream."""
+    module_id = "12:34:56:00:f1:63"
+    assert module_id in async_home.modules
+    module = async_home.modules[module_id]
+    assert module.device_type == DeviceType.NPC
+
+    async with await anyio.open_file(
+        f"fixtures/{response_fixture}",
+        encoding="utf-8",
+    ) as json_file:
+        response = json.loads(await json_file.read())
+
+    session_id = "af6da83b-1fd5-46ab-bf08-8e5db3cb9725"
+    sdp_offer = "sdp_test_offer"
+
+    with (
+        patch(
+            "pyatmo.auth.AbstractAsyncAuth.async_post_api_request",
+            AsyncMock(return_value=MockResponse(response, 200)),
+        ) as mock_resp,
+        exception,
+    ):
+        answer = await module.async_start_stream(session_id, sdp_offer)
+
+        mock_resp.assert_awaited_with(
+            params={
+                "home_id": async_home.entity_id,
+                "device_id": module_id,
+                "session_id": session_id,
+                "sdp": sdp_offer,
+            },
+            endpoint="api/webrtc/offer",
+        )
+
+        assert answer.stream.session_id == session_id
+        assert answer.stream.tag_id == "OZzgKVlQCW0="
+        assert answer.sdp == "sdp_test_answser"
+
+
+@pytest.mark.parametrize(
+    ("response_fixture", "exception"),
+    [
+        ("webrtc_terminate_ok.json", does_not_raise()),
+        ("webrtc_terminate_no_session.json", pytest.raises(ApiError)),
+    ],
+)
+async def test_async_webrtc_stream_stop(async_home, response_fixture, exception):
+    """Test stopping a WebRTC stream."""
+    module_id = "12:34:56:00:f1:63"
+    assert module_id in async_home.modules
+    module = async_home.modules[module_id]
+    assert module.device_type == DeviceType.NPC
+
+    async with await anyio.open_file(
+        f"fixtures/{response_fixture}",
+        encoding="utf-8",
+    ) as json_file:
+        response = json.loads(await json_file.read())
+
+    session_id = "af6da83b-1fd5-46ab-bf08-8e5db3cb9725"
+    tag_id = "OZzgKVlQCW0="
+
+    with (
+        patch(
+            "pyatmo.auth.AbstractAsyncAuth.async_post_api_request",
+            AsyncMock(return_value=MockResponse(response, 200)),
+        ) as mock_resp,
+        exception,
+    ):
+        await module.async_stop_stream(WebRTCStream(session_id, tag_id))
+
+        mock_resp.assert_awaited_with(
+            params={
+                "home_id": async_home.entity_id,
+                "device_id": module_id,
+                "session_id": session_id,
+                "tag_id": tag_id,
+            },
+            endpoint="api/webrtc/terminate",
+        )


### PR DESCRIPTION
## Context
The public cloud API provided by Netatmo now allows access to the live stream of the Netatmo Indoor Camera Advance (NPC). Unlike the other Netatmo cameras currently supported by `pyatmo`, which use HLS, the NPC provides access to its live stream via WebRTC.

To access a WebRTC live stream from a third-party application, the application must be reviewed and approved by Netatmo for privacy reasons. Unlike previous cameras, this requirement also applies when accessing your own cameras through your personal developer account. To test these changes, I used a privileged account provided by Netatmo specifically for this development.

Netatmo will reach out to the Open Home Foundation to grant access for Home Assistant. However, before this can happen, Netatmo needs to perform a small change to the NPC’s internal firmware, which means this process will unfortunately take some time.

In the meantime, I am working on adding live stream support for the NPC camera in Home Assistant, so that the feature will be ready to merge once Netatmo releases the required update. Implementing this support requires several changes in `pyatmo`, which is the purpose of this PR.

Note: The Netatmo Smart Video Doorbell (NDB) already uses WebRTC, but access to its live stream is not available via the public API. Therefore, while the NPC is not Netatmo’s first WebRTC-based camera, it is the first one to allow live stream access for third-party applications.

## Main changes
This PR mainly:
* Adds the two new API endpoints required to access a WebRTC live stream
* Adds the new API access scopes needed for the NPC
* Introduces a new `WebRTCCameraMixin` to implement WebRTC-specific functionality. Logic shared between WebRTC and HLS cameras is moved to a new `CameraMixinBase`.
* Adds fixtures and tests for WebRTC cameras.

## Documentation
* The Netatmo API: https://dev.netatmo.com/apidocumentation/security

## Summary by Sourcery

Add WebRTC streaming support and API integration for Netatmo Indoor Camera Advance and other WebRTC-capable cameras while unifying shared camera behavior.

New Features:
- Introduce WebRTC-specific data classes and mixins to model and control WebRTC camera streams, including start and stop operations via new API endpoints.
- Expose WebRTC stream primitives from the package API for use by downstream integrations.

Enhancements:
- Refactor camera mixins into a shared base class with protocol-specific HLS and WebRTC variants, centralizing URL selection and snapshot handling.
- Adjust camera module classes to use protocol-aware mixins and ensure correct local/VPN URL behavior across different camera types.

Tests:
- Extend and add tests and fixtures for live snapshot behavior and WebRTC start/stop flows, including success and error conditions for NPC cameras.