### PR TITLE
Fix: keyError when room id is not recognized

### DIFF
--- a/src/pyatmo/home.py
+++ b/src/pyatmo/home.py
@@ -185,10 +185,12 @@ class Home:
                 self.rooms[room["id"]].update(room)
             else:
                 LOG.warning(
-                    "Room id (%s) not found in known rooms: %s",
-                    room["id"], 
-                    self.rooms,
+                    "Room id (%s) not found in known rooms. Known room ids: %s (count=%d)",
+                    room["id"],
+                    list(self.rooms.keys()),
+                    len(self.rooms),
                 )
+
 
         for person_status in data.get("persons", []):
             # if there is a person update, it means the house has been updated

--- a/src/pyatmo/home.py
+++ b/src/pyatmo/home.py
@@ -181,7 +181,8 @@ class Home:
 
         for room in data.get("rooms", []):
             has_an_update = True
-            self.rooms[room["id"]].update(room)
+            if room["id"] in self.rooms.keys():
+                self.rooms[room["id"]].update(room)
 
         for person_status in data.get("persons", []):
             # if there is a person update, it means the house has been updated

--- a/src/pyatmo/home.py
+++ b/src/pyatmo/home.py
@@ -181,7 +181,7 @@ class Home:
 
         for room in data.get("rooms", []):
             has_an_update = True
-            if room["id"] in self.rooms.keys():
+            if room["id"] in self.rooms::
                 self.rooms[room["id"]].update(room)
 
         for person_status in data.get("persons", []):

--- a/src/pyatmo/home.py
+++ b/src/pyatmo/home.py
@@ -181,7 +181,7 @@ class Home:
 
         for room in data.get("rooms", []):
             has_an_update = True
-            if room["id"] in self.rooms::
+            if room["id"] in self.rooms:
                 self.rooms[room["id"]].update(room)
 
         for person_status in data.get("persons", []):

--- a/src/pyatmo/home.py
+++ b/src/pyatmo/home.py
@@ -183,6 +183,12 @@ class Home:
             has_an_update = True
             if room["id"] in self.rooms:
                 self.rooms[room["id"]].update(room)
+            else:
+                LOG.warning(
+                    "Room id (%s) not found in known rooms: %s",
+                    room["id"], 
+                    self.rooms,
+                )
 
         for person_status in data.get("persons", []):
             # if there is a person update, it means the house has been updated


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Avoid KeyError by only updating room entries that exist in the current rooms mapping.

Should solve https://github.com/jabesq-org/pyatmo/issues/534

## Summary by Sourcery

Bug Fixes:
- Guard room updates to avoid KeyError when an incoming room ID is not present in the current rooms mapping.

## Summary by Sourcery

Bug Fixes:
- Avoid KeyError by only updating room entries when the room ID exists in the current rooms mapping and log a warning for unknown IDs.