### PR TITLE
Add Category enum and mixin for NACamDoorTag

### DIFF
--- a/src/pyatmo/modules/base_class.py
+++ b/src/pyatmo/modules/base_class.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING, Any
 
 from pyatmo.const import GPS_COORDINATES_COUNT, MAX_HISTORY_TIME_FRAME, RawData
 from pyatmo.event import EventTypes
-from pyatmo.modules.device_types import ApplianceType, DeviceType
+from pyatmo.modules.device_types import ApplianceType, DeviceType, DoorTagCategory
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterator
@@ -35,6 +35,7 @@ NETATMO_ATTRIBUTES_MAP: dict[str, Callable[[dict[str, Any], Any], Any]] = {
     "place": lambda x, _: Place(x.get("place")),
     "target_position__step": lambda x, _: x.get("target_position:step"),
     "appliance_type": lambda x, y: ApplianceType(x.get("appliance_type", y)),
+    "doortag_category": lambda x, y: DoorTagCategory(x.get("doortag_category", y)),
 }
 
 

--- a/src/pyatmo/modules/base_class.py
+++ b/src/pyatmo/modules/base_class.py
@@ -35,7 +35,7 @@ NETATMO_ATTRIBUTES_MAP: dict[str, Callable[[dict[str, Any], Any], Any]] = {
     "place": lambda x, _: Place(x.get("place")),
     "target_position__step": lambda x, _: x.get("target_position:step"),
     "appliance_type": lambda x, y: ApplianceType(x.get("appliance_type", y)),
-    "doortag_category": lambda x, y: DoorTagCategory(x.get("doortag_category", y)),
+    "doortag_category": lambda x, y: DoorTagCategory(x.get("category", y)),
 }
 
 

--- a/src/pyatmo/modules/device_types.py
+++ b/src/pyatmo/modules/device_types.py
@@ -323,3 +323,25 @@ class ApplianceType(str, Enum):
         msg: str = f"{key} appliance type is unknown"
         LOG.warning(msg)
         return ApplianceType.unknown
+
+
+class Category(str, Enum):
+    """Class to represent category of a module. This is only for Home + Security/NACamDoorTag."""
+
+    # temporarily disable locally-disabled and locally-enabled
+
+    door = "door"
+    furniture = "furniture"
+    garage = "garage"
+    gate = "gate"
+    other = "other"
+    window = "window"
+    unknown = "unknown"
+
+    @classmethod
+    def _missing_(cls, key: object) -> Literal[Category.unknown]:
+        """Handle unknown device category."""
+
+        msg: str = f"{key} category is unknown"
+        LOG.warning(msg)
+        return Category.unknown

--- a/src/pyatmo/modules/device_types.py
+++ b/src/pyatmo/modules/device_types.py
@@ -328,8 +328,6 @@ class ApplianceType(str, Enum):
 class DoorTagCategory(str, Enum):
     """Class to represent category of a module. This is only for Home + Security/NACamDoorTag."""
 
-    # temporarily disable locally-disabled and locally-enabled
-
     door = "door"
     furniture = "furniture"
     garage = "garage"

--- a/src/pyatmo/modules/device_types.py
+++ b/src/pyatmo/modules/device_types.py
@@ -325,7 +325,7 @@ class ApplianceType(str, Enum):
         return ApplianceType.unknown
 
 
-class Category(str, Enum):
+class DoorTagCategory(str, Enum):
     """Class to represent category of a module. This is only for Home + Security/NACamDoorTag."""
 
     # temporarily disable locally-disabled and locally-enabled
@@ -339,9 +339,9 @@ class Category(str, Enum):
     unknown = "unknown"
 
     @classmethod
-    def _missing_(cls, key: object) -> Literal[Category.unknown]:
+    def _missing_(cls, key: object) -> Literal[DoorTagCategory.unknown]:
         """Handle unknown device category."""
 
         msg: str = f"{key} category is unknown"
         LOG.warning(msg)
-        return Category.unknown
+        return DoorTagCategory.unknown

--- a/src/pyatmo/modules/module.py
+++ b/src/pyatmo/modules/module.py
@@ -327,7 +327,7 @@ class DoorTagCategoryMixin(EntityBase):
 
         super().__init__(home, module)
         self.doortag_category: DoorTagCategory | None = module.get(
-            "doortag_category",
+            "category",
             DoorTagCategory.unknown,
         )
 

--- a/src/pyatmo/modules/module.py
+++ b/src/pyatmo/modules/module.py
@@ -17,9 +17,9 @@ from pyatmo.modules.base_class import EntityBase, NetatmoBase, Place, update_nam
 from pyatmo.modules.device_types import (
     DEVICE_CATEGORY_MAP,
     ApplianceType,
-    Category,
     DeviceCategory,
     DeviceType,
+    DoorTagCategory,
 )
 
 if TYPE_CHECKING:
@@ -318,18 +318,18 @@ class ApplianceTypeMixin(EntityBase):
         )
 
 
-class CategoryMixin(EntityBase):
+class DoorTagCategoryMixin(EntityBase):
     """Mixin for category data."""
 
-    category: Category | None
+    doortag_category: DoorTagCategory | None
 
     def __init__(self, home: Home, module: ModuleT) -> None:
         """Initialize category mixin."""
 
         super().__init__(home, module)
-        self.appliance_type: Category | None = module.get(
+        self.doortag_category: DoorTagCategory | None = module.get(
             "category",
-            Category.unknown,
+            DoorTagCategory.unknown,
         )
 
 

--- a/src/pyatmo/modules/module.py
+++ b/src/pyatmo/modules/module.py
@@ -17,6 +17,7 @@ from pyatmo.modules.base_class import EntityBase, NetatmoBase, Place, update_nam
 from pyatmo.modules.device_types import (
     DEVICE_CATEGORY_MAP,
     ApplianceType,
+    Category,
     DeviceCategory,
     DeviceType,
 )
@@ -35,6 +36,7 @@ ATTRIBUTE_FILTER = {
     "battery_state",
     "battery_level",
     "battery_percent",
+    "category",
     "date_min_temp",
     "date_max_temp",
     "name",
@@ -313,6 +315,21 @@ class ApplianceTypeMixin(EntityBase):
         self.appliance_type: ApplianceType | None = module.get(
             "appliance_type",
             ApplianceType.unknown,
+        )
+
+
+class CategoryMixin(EntityBase):
+    """Mixin for category data."""
+
+    category: Category | None
+
+    def __init__(self, home: Home, module: ModuleT) -> None:
+        """Initialize category mixin."""
+
+        super().__init__(home, module)
+        self.appliance_type: Category | None = module.get(
+            "category",
+            Category.unknown,
         )
 
 

--- a/src/pyatmo/modules/module.py
+++ b/src/pyatmo/modules/module.py
@@ -36,7 +36,6 @@ ATTRIBUTE_FILTER = {
     "battery_state",
     "battery_level",
     "battery_percent",
-    "category",
     "date_min_temp",
     "date_max_temp",
     "name",
@@ -328,7 +327,7 @@ class DoorTagCategoryMixin(EntityBase):
 
         super().__init__(home, module)
         self.doortag_category: DoorTagCategory | None = module.get(
-            "category",
+            "doortag_category",
             DoorTagCategory.unknown,
         )
 

--- a/src/pyatmo/modules/netatmo.py
+++ b/src/pyatmo/modules/netatmo.py
@@ -23,8 +23,8 @@ from pyatmo.modules.module import (
     BatteryMixin,
     BoilerMixin,
     Camera,
-    CategoryMixin,
     CO2Mixin,
+    DoorTagCategoryMixin,
     FirmwareMixin,
     FloodlightMixin,
     HealthIndexMixin,
@@ -148,7 +148,7 @@ class NHC(
 
 
 class NACamDoorTag(
-    StatusMixin, FirmwareMixin, BatteryMixin, RfMixin, CategoryMixin, Module
+    StatusMixin, FirmwareMixin, BatteryMixin, RfMixin, DoorTagCategoryMixin, Module
 ):
     """Class to represent a Netatmo NACamDoorTag."""
 

--- a/src/pyatmo/modules/netatmo.py
+++ b/src/pyatmo/modules/netatmo.py
@@ -23,6 +23,7 @@ from pyatmo.modules.module import (
     BatteryMixin,
     BoilerMixin,
     Camera,
+    CategoryMixin,
     CO2Mixin,
     FirmwareMixin,
     FloodlightMixin,
@@ -146,7 +147,9 @@ class NHC(
     """Class to represent a Netatmo NHC."""
 
 
-class NACamDoorTag(StatusMixin, FirmwareMixin, BatteryMixin, RfMixin, Module):
+class NACamDoorTag(
+    StatusMixin, FirmwareMixin, BatteryMixin, RfMixin, CategoryMixin, Module
+):
     """Class to represent a Netatmo NACamDoorTag."""
 
 


### PR DESCRIPTION
For `NACamDoorTag` there is a `category` that describes what type of opening the doortag is used. The change is proposing a `doortag_category` among the device `feature`-s to expose this.

## Summary by Sourcery

Introduce a category concept for NACamDoorTag modules and expose it via the module feature set.

New Features:
- Add a DoorTagCategory enum to represent NACamDoorTag opening types such as door, window, garage, and others.
- Introduce a DoorTagCategoryMixin to surface the category field as a module feature and apply it to NACamDoorTag entities.