### PR TITLE
Add siren control support for NOC (Smart Outdoor Camera)

### DIFF
--- a/fixtures/homestatus_91763b24c43d3e344f424e8b.json
+++ b/fixtures/homestatus_91763b24c43d3e344f424e8b.json
@@ -129,6 +129,7 @@
           "network_lock": false,
           "firmware_name": "3.2.0",
           "wifi_strength": 62,
+          "siren_status": "no_sound",
           "alim_status": 2,
           "locked": false,
           "wifi_state": "high"

--- a/src/pyatmo/modules/module.py
+++ b/src/pyatmo/modules/module.py
@@ -577,6 +577,39 @@ class FloodlightMixin(EntityBase):
         return await self.async_set_floodlight_state("auto")
 
 
+class SirenMixin(EntityBase):
+    """Mixin for siren data."""
+
+    def __init__(self, home: Home, module: ModuleT) -> None:
+        """Initialize siren mixin."""
+
+        super().__init__(home, module)
+        self.siren_status: str | None = None
+
+    async def async_set_siren_state(self, state: str) -> bool:
+        """Set siren state."""
+
+        json_siren_state = {
+            "modules": [
+                {
+                    "id": self.entity_id,
+                    "siren_status": state,
+                },
+            ],
+        }
+        return await self.home.async_set_state(json_siren_state)
+
+    async def async_siren_on(self) -> bool:
+        """Turn on siren."""
+
+        return await self.async_set_siren_state("sound")
+
+    async def async_siren_off(self) -> bool:
+        """Turn off siren."""
+
+        return await self.async_set_siren_state("no_sound")
+
+
 class StatusMixin(EntityBase):
     """Mixin for status data."""
 

--- a/src/pyatmo/modules/netatmo.py
+++ b/src/pyatmo/modules/netatmo.py
@@ -35,6 +35,7 @@ from pyatmo.modules.module import (
     PressureMixin,
     RainMixin,
     RfMixin,
+    SirenMixin,
     StatusMixin,
     TemperatureMixin,
     WifiMixin,
@@ -76,7 +77,7 @@ class NPC(Camera):
     """Class to represent a Netatmo NPC."""
 
 
-class NOC(FloodlightMixin, Camera):
+class NOC(SirenMixin, FloodlightMixin, Camera):
     """Class to represent a Netatmo NOC."""
 
 

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, patch
 import anyio
 
 from pyatmo import DeviceType
+from pyatmo.modules.module import SirenMixin
 from tests.common import MockResponse
 
 
@@ -191,3 +192,13 @@ async def test_async_camera_siren(async_home):
             params=gen_json_data("no_sound"),
             endpoint="api/setstate",
         )
+
+
+async def test_async_camera_siren_missing_status(async_home):
+    """Test that NOC handles missing siren_status in API payload gracefully."""
+    module_id = "12:34:56:10:b9:0e"
+    module = async_home.modules[module_id]
+
+    # Simulate an API response without siren_status (e.g. older firmware)
+    module.siren_status = None
+    assert module.siren_status is None

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -55,6 +55,7 @@ async def test_async_NOC(async_home):
     assert module.alim_status == 2
     assert module.is_local is False
     assert module.floodlight == "auto"
+    assert module.siren_status == "no_sound"
 
     async with await anyio.open_file(
         "fixtures/status_ok.json",
@@ -142,5 +143,51 @@ async def test_async_camera_monitoring(async_home):
         assert await module.async_monitoring_off()
         mock_resp.assert_awaited_with(
             params=gen_json_data("off"),
+            endpoint="api/setstate",
+        )
+
+
+async def test_async_camera_siren(async_home):
+    """Test basic camera siren functionality."""
+    module_id = "12:34:56:10:b9:0e"
+    assert module_id in async_home.modules
+    module = async_home.modules[module_id]
+    assert module.device_type == DeviceType.NOC
+    assert module.siren_status == "no_sound"
+
+    async with await anyio.open_file(
+        "fixtures/status_ok.json",
+        encoding="utf-8",
+    ) as json_file:
+        response = json.loads(await json_file.read())
+
+    def gen_json_data(state):
+        return {
+            "json": {
+                "home": {
+                    "id": "91763b24c43d3e344f424e8b",
+                    "modules": [
+                        {
+                            "id": module_id,
+                            "siren_status": state,
+                        },
+                    ],
+                },
+            },
+        }
+
+    with patch(
+        "pyatmo.auth.AbstractAsyncAuth.async_post_api_request",
+        AsyncMock(return_value=MockResponse(response, 200)),
+    ) as mock_resp:
+        assert await module.async_siren_on()
+        mock_resp.assert_awaited_with(
+            params=gen_json_data("sound"),
+            endpoint="api/setstate",
+        )
+
+        assert await module.async_siren_off()
+        mock_resp.assert_awaited_with(
+            params=gen_json_data("no_sound"),
             endpoint="api/setstate",
         )


### PR DESCRIPTION
## Summary

- Add `SirenMixin` with `async_siren_on()` / `async_siren_off()` methods for controlling the NOC built-in siren
- Wire `SirenMixin` into the `NOC` class
- Add corresponding test coverage

## Details

The Netatmo Smart Outdoor Camera (NOC) has a built-in siren that can be controlled via the `setstate` API endpoint using the `siren_status` parameter with values `sound` and `no_sound`.

This has been validated by:
1. Confirming `siren_status` is returned by the `homestatus` API for NOC devices
2. Successfully sending `setstate` calls with `siren_status` to both `app.netatmo.net` and `api.netatmo.com` endpoints
3. Physically confirming the siren activates and deactivates on a real NOC device

The implementation follows the exact same pattern as `FloodlightMixin`.

## Summary by Sourcery

Add siren control support for Netatmo Smart Outdoor Camera (NOC) via a reusable mixin and integrate it into the existing camera module model.

New Features:
- Introduce a reusable SirenMixin providing async methods to turn the camera siren on and off.
- Enable siren status handling for NOC camera modules, exposing current siren state from API data.

Tests:
- Add asynchronous tests verifying NOC siren status parsing and API interactions for turning the siren on and off.