### PR TITLE
Add VELUX ACTIVE module support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
--
+- Support for VELUX ACTIVE gateways (`NXG`) and covers (`NXO`)
 
 ### Changed
 

--- a/fixtures/homesdata_velux.json
+++ b/fixtures/homesdata_velux.json
@@ -1,0 +1,57 @@
+{
+  "status": "ok",
+  "body": {
+    "homes": [
+      {
+        "id": "velux_home_id",
+        "name": "VELUX Test Home",
+        "modules": [
+          {
+            "id": "velux_gateway_id",
+            "type": "NXG",
+            "name": "Gateway 1",
+            "subtype": "EU",
+            "reachable": true,
+            "modules_bridged": [
+              "velux_opener_awning",
+              "velux_opener_blind"
+            ],
+            "pincode_enabled": false
+          },
+          {
+            "id": "velux_opener_awning",
+            "type": "NXO",
+            "name": "Bedroom Awning",
+            "bridge": "velux_gateway_id",
+            "room_id": "velux_room_id",
+            "velux_type": "awning_blind"
+          },
+          {
+            "id": "velux_opener_blind",
+            "type": "NXO",
+            "name": "Bedroom Blind",
+            "bridge": "velux_gateway_id",
+            "room_id": "velux_room_id",
+            "velux_type": "blind"
+          }
+        ],
+        "rooms": [
+          {
+            "id": "velux_room_id",
+            "name": "Bedroom",
+            "module_ids": [
+              "velux_opener_awning",
+              "velux_opener_blind"
+            ]
+          }
+        ],
+        "schedules": [],
+        "persons": []
+      }
+    ],
+    "user": {
+      "email": "velux@example.com"
+    },
+    "errors": []
+  }
+}

--- a/fixtures/homestatus_velux_home_id.json
+++ b/fixtures/homestatus_velux_home_id.json
@@ -1,0 +1,57 @@
+{
+  "status": "ok",
+  "body": {
+    "home": {
+      "modules": [
+        {
+          "id": "velux_gateway_id",
+          "type": "NXG",
+          "wifi_strength": 44,
+          "locked": true,
+          "locking": false,
+          "secure": true,
+          "busy": false,
+          "calibrating": false,
+          "pairing": false,
+          "is_raining": false,
+          "last_seen": 1776675797,
+          "hardware_version": 1,
+          "firmware_revision_netatmo": 10,
+          "firmware_revision_thirdparty": 14
+        },
+        {
+          "id": "velux_opener_awning",
+          "type": "NXO",
+          "bridge": "velux_gateway_id",
+          "current_position": 100,
+          "target_position": 100,
+          "mode": "algo_disabled",
+          "reachable": true,
+          "velux_type": "awning_blind",
+          "silent": false,
+          "manufacturer": "Netatmo",
+          "last_seen": 1776675797,
+          "firmware_revision": 14
+        },
+        {
+          "id": "velux_opener_blind",
+          "type": "NXO",
+          "bridge": "velux_gateway_id",
+          "current_position": 0,
+          "target_position": 0,
+          "mode": "algo_disabled",
+          "reachable": true,
+          "velux_type": "blind",
+          "silent": false,
+          "manufacturer": "Netatmo",
+          "last_seen": 1776675797,
+          "firmware_revision": 14
+        }
+      ],
+      "rooms": [],
+      "persons": [],
+      "events": []
+    },
+    "errors": []
+  }
+}

--- a/src/pyatmo/modules/__init__.py
+++ b/src/pyatmo/modules/__init__.py
@@ -85,6 +85,7 @@ from .netatmo import (
 )
 from .smarther import BNS
 from .somfy import TPSRS
+from .velux import NXG, NXO
 
 __all__ = [
     "BNAB",
@@ -150,6 +151,8 @@ __all__ = [
     "NPC",
     "NRV",
     "NSD",
+    "NXG",
+    "NXO",
     "OTH",
     "OTM",
     "TPSRS",

--- a/src/pyatmo/modules/device_types.py
+++ b/src/pyatmo/modules/device_types.py
@@ -101,6 +101,10 @@ class DeviceType(str, Enum):
     NBR = "NBR"  # roller shutter
     NBS = "NBS"  # swing shutter
 
+    # VELUX ACTIVE
+    NXG = "NXG"  # gateway
+    NXO = "NXO"  # opener / cover
+
     # Somfy
     TPSRS = "TPSRS"  # Somfy io shutter
 
@@ -163,6 +167,7 @@ DEVICE_CATEGORY_MAP: dict[DeviceType, DeviceCategory] = {
     DeviceType.NLLM: DeviceCategory.shutter,
     DeviceType.NBR: DeviceCategory.shutter,
     DeviceType.NBO: DeviceCategory.shutter,
+    DeviceType.NXO: DeviceCategory.shutter,
     DeviceType.NLP: DeviceCategory.switch,
     DeviceType.NLPM: DeviceCategory.switch,
     DeviceType.NLPBS: DeviceCategory.switch,
@@ -281,6 +286,9 @@ DEVICE_DESCRIPTION_MAP: dict[DeviceType, tuple[str, str]] = {
     DeviceType.NBR: ("Bubbendorf", "Roller Shutter"),
     DeviceType.NBO: ("Bubbendorf", "Orientable Shutter"),
     DeviceType.NBS: ("Bubbendorf", "Swing Shutter"),
+    # VELUX ACTIVE
+    DeviceType.NXG: ("VELUX ACTIVE", "Gateway"),
+    DeviceType.NXO: ("VELUX ACTIVE", "Opener"),
     # Somfy
     DeviceType.TPSRS: ("Somfy", "io Shutter"),
     # 3rd Party

--- a/src/pyatmo/modules/velux.py
+++ b/src/pyatmo/modules/velux.py
@@ -1,0 +1,61 @@
+"""Module to represent VELUX ACTIVE modules."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from pyatmo.modules.module import EntityBase, Module, Shutter, WifiMixin
+
+if TYPE_CHECKING:
+    from pyatmo.const import RawData
+    from pyatmo.home import Home
+    from pyatmo.modules.module import ModuleT
+
+
+class VeluxGatewayMixin(EntityBase):
+    """Mixin for VELUX gateway specific data."""
+
+    def __init__(self, home: Home, module: ModuleT) -> None:
+        """Initialize VELUX gateway data."""
+        super().__init__(home, module)
+        self.subtype: str | None = None
+        self.firmware_revision_netatmo: int | None = None
+        self.firmware_revision_thirdparty: int | None = None
+        self.hardware_version: int | None = None
+        self.last_seen: int | None = None
+        self.last_reset_type: str | None = None
+        self.busy: bool | None = None
+        self.calibrating: bool | None = None
+        self.is_raining: bool | None = None
+        self.locked: bool | None = None
+        self.locking: bool | None = None
+        self.pairing: bool | None = None
+        self.pincode_enabled: bool | None = None
+        self.secure: bool | None = None
+
+
+class VeluxOpenerMixin(EntityBase):
+    """Mixin for VELUX cover specific data."""
+
+    def __init__(self, home: Home, module: ModuleT) -> None:
+        """Initialize VELUX cover data."""
+        super().__init__(home, module)
+        self.last_seen: int | None = None
+        self.manufacturer: str | None = None
+        self.mode: str | None = None
+        self.silent: bool | None = None
+        self.velux_type: str | None = None
+
+
+class NXG(VeluxGatewayMixin, WifiMixin, Module):
+    """Class to represent a VELUX ACTIVE gateway."""
+
+    async def update(self, raw_data: RawData) -> None:
+        """Update gateway state without cascading gateway data into bridged covers."""
+
+        self.update_topology(raw_data)
+        self.update_features()
+
+
+class NXO(VeluxOpenerMixin, Shutter):
+    """Class to represent a VELUX ACTIVE opener / cover."""

--- a/tests/test_velux.py
+++ b/tests/test_velux.py
@@ -1,0 +1,123 @@
+"""Define tests for VELUX ACTIVE modules."""
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pyatmo
+from pyatmo import DeviceType
+from pyatmo.modules.device_types import DeviceCategory
+from tests.common import MockResponse, load_fixture
+
+
+async def test_async_velux_modules(async_auth):
+    """Test VELUX gateway and cover parsing."""
+    homesdata = json.loads(load_fixture("homesdata_velux.json"))
+    homestatus = json.loads(load_fixture("homestatus_velux_home_id.json"))
+    homestatus["body"]["home"]["modules"][0]["name"] = "VELUX gateway"
+    homestatus["body"]["home"]["modules"][0]["reachable"] = False
+
+    account = pyatmo.AsyncAccount(async_auth)
+
+    with patch(
+        "pyatmo.auth.AbstractAsyncAuth.async_post_api_request",
+        AsyncMock(
+            side_effect=[
+                MockResponse(homesdata, 200),
+                MockResponse(homestatus, 200),
+            ],
+        ),
+    ):
+        await account.async_update_topology()
+        await account.async_update_status("velux_home_id")
+
+    home = account.homes["velux_home_id"]
+    assert home.name == "VELUX Test Home"
+
+    gateway = home.modules["velux_gateway_id"]
+    assert gateway.device_type == DeviceType.NXG
+    assert gateway.device_category is None
+    assert gateway.wifi_strength == 44
+    assert gateway.locked is True
+    assert gateway.locking is False
+    assert gateway.secure is True
+    assert gateway.modules == ["velux_opener_awning", "velux_opener_blind"]
+
+    opener = home.modules["velux_opener_awning"]
+    assert opener.device_type == DeviceType.NXO
+    assert opener.device_category == DeviceCategory.shutter
+    assert opener.name == "Bedroom Awning"
+    assert opener.bridge == "velux_gateway_id"
+    assert opener.current_position == 100
+    assert opener.target_position == 100
+    assert opener.mode == "algo_disabled"
+    assert opener.reachable is True
+    assert opener.silent is False
+    assert opener.velux_type == "awning_blind"
+    assert opener.manufacturer == "Netatmo"
+    assert opener.firmware_revision == 14
+
+    blind = home.modules["velux_opener_blind"]
+    assert blind.name == "Bedroom Blind"
+
+    room = home.rooms["velux_room_id"]
+    assert room.device_types == {DeviceType.NXO}
+
+
+async def test_async_shutter_nxo(async_auth):
+    """Test VELUX cover control payloads."""
+    homesdata = json.loads(load_fixture("homesdata_velux.json"))
+    homestatus = json.loads(load_fixture("homestatus_velux_home_id.json"))
+
+    account = pyatmo.AsyncAccount(async_auth)
+
+    with patch(
+        "pyatmo.auth.AbstractAsyncAuth.async_post_api_request",
+        AsyncMock(
+            side_effect=[
+                MockResponse(homesdata, 200),
+                MockResponse(homestatus, 200),
+            ],
+        ),
+    ):
+        await account.async_update_topology()
+        await account.async_update_status("velux_home_id")
+
+    module = account.homes["velux_home_id"].modules["velux_opener_awning"]
+
+    def gen_json_data(position):
+        return {
+            "json": {
+                "home": {
+                    "id": "velux_home_id",
+                    "modules": [
+                        {
+                            "bridge": "velux_gateway_id",
+                            "id": "velux_opener_awning",
+                            "target_position": position,
+                        },
+                    ],
+                },
+            },
+        }
+
+    with patch(
+        "pyatmo.auth.AbstractAsyncAuth.async_post_api_request",
+        AsyncMock(return_value=MockResponse({"status": "ok"}, 200)),
+    ) as mock_resp:
+        assert await module.async_open()
+        mock_resp.assert_awaited_with(
+            params=gen_json_data(100),
+            endpoint="api/setstate",
+        )
+
+        assert await module.async_close()
+        mock_resp.assert_awaited_with(
+            params=gen_json_data(0),
+            endpoint="api/setstate",
+        )
+
+        assert await module.async_stop()
+        mock_resp.assert_awaited_with(
+            params=gen_json_data(-1),
+            endpoint="api/setstate",
+        )


### PR DESCRIPTION
## Summary

This PR adds VELUX ACTIVE Home+Control device support to `pyatmo`.

It introduces support for:
- `NXG` VELUX ACTIVE gateways
- `NXO` VELUX ACTIVE covers / openers

## What Changed

- Added a new `pyatmo.modules.velux` module with `NXG` and `NXO` classes
- Registered `NXG` and `NXO` in `DeviceType`
- Mapped `NXO` to the existing `shutter` device category
- Added VELUX ACTIVE device descriptions for Home Assistant / downstream consumers
- Exported the new module classes through `pyatmo.modules`
- Added VELUX-specific fixtures and tests for parsing and shutter control

`NXO` is modeled as a normal `Shutter`, so downstream integrations can treat it like the other supported Netatmo cover types.

## Why

VELUX ACTIVE uses the same Netatmo Home+Control API family, but exposes VELUX-specific device types that `pyatmo` does not currently recognize.

Without these additions:
- VELUX devices fall back to unknown module handling
- `NXO` covers are not exposed as shutters
- downstream integrations cannot interact with VELUX covers using the existing cover path

## Root Cause / Fix

During validation, VELUX gateways (`NXG`) reported bridged cover modules correctly in topology data, but gateway status updates could overwrite bridged cover names with the gateway name if the generic bridged-module update path was used.

To keep the fix local to VELUX support, `NXG` overrides `update()` so gateway status is processed without cascading gateway payload data into bridged `NXO` modules. This preserves the real cover names from topology while still updating gateway attributes.

## Impact

This enables downstream consumers such as Home Assistant's Netatmo integration stack to recognize VELUX ACTIVE covers as shutters using the existing model shape, instead of needing a separate ad hoc device representation.

## Validation

- `uv run pytest`
- `uv run ruff check src/pyatmo/modules/velux.py tests/test_home.py tests/test_velux.py`

I also verified the payload shape against a live VELUX ACTIVE account while preparing the fixtures and model support.

## Summary by Sourcery

Add support for VELUX ACTIVE Home+Control devices and ensure they are modeled consistently with existing shutter modules.

New Features:
- Introduce NXG gateway and NXO opener modules to represent VELUX ACTIVE devices.
- Expose NXG and NXO through the public modules package and map NXO devices to the shutter category.
- Provide device metadata for VELUX ACTIVE modules for downstream consumers such as Home Assistant.

Documentation:
- Document VELUX ACTIVE support in the changelog.

Tests:
- Add fixtures and tests to validate VELUX topology/status parsing and shutter control behavior for NXO covers.