### PR TITLE
Fix typo in device_types.py for cooking

### DIFF
--- a/src/pyatmo/modules/device_types.py
+++ b/src/pyatmo/modules/device_types.py
@@ -306,7 +306,7 @@ class ApplianceType(str, Enum):
     multimedia = "multimedia"
     router = "router"
     other = "other"
-    ooking = "cooking"
+    cooking = "cooking"
     radiator = "radiator"
     radiator_without_pilot_wire = "radiator_without_pilot_wire"
     water_heater = "water_heater"


### PR DESCRIPTION
According to [API description](https://dev.netatmo.com/apidocumentation/control#homesdata) should be: enum:[
"light"
"fridge_freezer"
"oven"
"washing_machine"
"tumble_dryer"
"dishwasher"
"multimedia"
"router"
"other"
"cooking"
"radiator"
"radiator_without_pilot_wire"
"water_heater"
"extractor_hood"
"contactor"
"dryer"
"electric_charger"
]

## Summary by Sourcery

Bug Fixes:
- Fix a typo in the appliance type enum by renaming the misnamed 'ooking' value to 'cooking' to align with the API specification.