### PR TITLE
Add Velux algo schedule type

### DIFF
--- a/src/pyatmo/enums.py
+++ b/src/pyatmo/enums.py
@@ -12,6 +12,7 @@ class ScheduleType(StrEnum):
     ELECTRICITY_PRODUCTION = "electricity_production"
     EVENT = "event"
     AUTO = "auto"
+    ALGO = "algo"
 
 
 class TemperatureControlMode(StrEnum):


### PR DESCRIPTION
## Summary
- Add the Velux `algo` schedule type to `ScheduleType`.
- Allows clients to parse Velux automatic algorithm schedules without an unknown enum value.

## Testing
- Not run; enum-only change.

## Summary by Sourcery

New Features:
- Introduce the "algo" value to the ScheduleType enum for Velux automatic algorithm schedules.