### PR TITLE
fix: log setstate body errors

### DIFF
--- a/src/pyatmo/home.py
+++ b/src/pyatmo/home.py
@@ -338,7 +338,17 @@ class Home:
             params={"json": {"home": {"id": self.entity_id, **data}}},
         )
 
-        return (await resp.json()).get("status") == "ok"
+        response = await resp.json()
+        body = response.get("body")
+        if isinstance(body, dict) and (errors := body.get("errors")):
+            LOG.warning(
+                "Set state response for home %s contains errors: status=%r errors=%r",
+                self.entity_id,
+                response.get("status"),
+                errors,
+            )
+            return False
+        return response.get("status") == "ok"
 
     async def async_set_persons_home(
         self,

--- a/tests/test_shutter.py
+++ b/tests/test_shutter.py
@@ -1,6 +1,7 @@
 """Define tests for shutter module."""
 
 import json
+import logging
 from unittest.mock import AsyncMock, patch
 
 import anyio
@@ -114,4 +115,52 @@ async def test_async_shutters(async_home):
         mock_resp.assert_awaited_with(
             params=gen_json_data(100),
             endpoint="api/setstate",
+        )
+
+
+async def test_async_shutter_returns_false_on_setstate_body_errors(async_home, caplog):
+    """Test shutter command with setstate body errors."""
+    module_id = "0009999992"
+    module = async_home.modules[module_id]
+
+    response = {
+        "status": "ok",
+        "body": {
+            "home": {"id": "91763b24c43d3e344f424e8b"},
+            "errors": [{"code": 9, "id": module_id}],
+        },
+    }
+
+    with patch(
+        "pyatmo.auth.AbstractAsyncAuth.async_post_api_request",
+        AsyncMock(return_value=MockResponse(response, 200)),
+    ) as mock_resp:
+        with caplog.at_level(logging.WARNING, logger="pyatmo.home"):
+            assert not await module.async_open()
+        mock_resp.assert_awaited_with(
+            params={
+                "json": {
+                    "home": {
+                        "id": "91763b24c43d3e344f424e8b",
+                        "modules": [
+                            {
+                                "bridge": "12:34:56:30:d5:d4",
+                                "id": module_id,
+                                "target_position": 100,
+                            },
+                        ],
+                    },
+                },
+            },
+            endpoint="api/setstate",
+        )
+        assert len(caplog.records) == 1
+        record = caplog.records[0]
+        assert record.msg == (
+            "Set state response for home %s contains errors: status=%r errors=%r"
+        )
+        assert record.args == (
+            "91763b24c43d3e344f424e8b",
+            "ok",
+            response["body"]["errors"],
         )


### PR DESCRIPTION
## Summary
- return `False` from `Home.async_set_state()` when a `/api/setstate` response contains `body.errors`
- log the body error payload so callers can see why a command was rejected
- add a shutter regression test for setstate body errors

## Background
The Netatmo API documentation for [`200 OK`](https://dev.netatmo.com/apidocumentation/general#status-ok) notes that product-level errors can still be returned in the response body after a well-formed request reaches the backend. In that case, the action may not be fully applied and the response contains an `errors` array in `body`.

Currently `async_set_state()` only checks the top-level `status`, so a response like `status: ok` with non-empty `body.errors` is treated as successful.

## Testing
- `uv run ruff check src/pyatmo/home.py tests/test_shutter.py`
- `uv run pytest tests/test_shutter.py`
- `uv run pytest`
- `uv run tox -e mypy`

## Summary by Sourcery

Handle Netatmo set state responses that include body-level errors and ensure shutter commands report failures correctly.

Bug Fixes:
- Treat /api/setstate responses with non-empty body.errors as failed operations instead of successful ones.
- Log the error payload from set state responses so callers can see why a command was rejected.

Tests:
- Add a regression test verifying that shutter open commands return False and emit a warning log when setstate responses contain body.errors.