### PR TITLE
fix: exclude doortag_category from module features set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
--
+- Exclude `doortag_category` from the `NACamDoorTag` `features` set, matching the
+  handling of the sibling metadata attributes `device_category` and `appliance_type`
+  (#500)
 
 ### Removed
 

--- a/src/pyatmo/modules/module.py
+++ b/src/pyatmo/modules/module.py
@@ -60,6 +60,7 @@ ATTRIBUTE_FILTER = {
     "history_features",
     "history_features_values",
     "appliance_type",
+    "doortag_category",
 }
 
 

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -6,9 +6,21 @@ from unittest.mock import AsyncMock, patch
 import anyio
 import pytest
 
-from pyatmo import ApiError, DeviceType, SIREN_BASE_URL, WebRTCStream
+from pyatmo import SIREN_BASE_URL, ApiError, DeviceType, WebRTCStream
+from pyatmo.modules.device_types import DeviceCategory, DoorTagCategory
 from tests.common import MockResponse
 from tests.conftest import does_not_raise
+
+
+async def test_async_doortag_NACamDoorTag(async_home):
+    """NACamDoorTag exposes doortag_category, keeps device_category, no feature leak."""
+    module_id = "12:34:56:00:86:99"
+    assert module_id in async_home.modules
+    module = async_home.modules[module_id]
+    assert module.device_type == DeviceType.NACamDoorTag
+    assert module.doortag_category == DoorTagCategory.window
+    assert module.device_category == DeviceCategory.opening
+    assert "doortag_category" not in module.features
 
 
 async def test_async_camera_NACamera(async_home):

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -21,6 +21,7 @@ async def test_async_doortag_NACamDoorTag(async_home):
     assert module.doortag_category == DoorTagCategory.window
     assert module.device_category == DeviceCategory.opening
     assert "doortag_category" not in module.features
+    assert "device_category" not in module.features
 
 
 async def test_async_camera_NACamera(async_home):


### PR DESCRIPTION
NACamDoorTag exposed "doortag_category" in its `features` set because PR #553 added the DoorTagCategoryMixin attribute but omitted it from ATTRIBUTE_FILTER, unlike the sibling metadata attrs device_category and appliance_type. The attribute is descriptive metadata, not a capability, so it should not appear in features.

Add "doortag_category" to ATTRIBUTE_FILTER and add a regression test asserting NACamDoorTag still exposes doortag_category and device_category while keeping it out of the features set.

resolves: https://github.com/jabesq-org/pyatmo/issues/426

## Summary by Sourcery

Exclude descriptive DoorTag metadata from module feature capabilities and add coverage for NACamDoorTag metadata and feature set behavior.

Bug Fixes:
- Prevent doortag_category metadata from being exposed as a module feature capability for NACamDoorTag.

Tests:
- Add an async NACamDoorTag test verifying doortag_category and device_category metadata are present while doortag_category is absent from the features set.