### PR TITLE
feat: parse offload_meters on offload modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   backoff, honoring the response `Retry-After` header when present (#547)
 - Parse the `last_seen` availability timestamp for all modules (previously only
   VELUX modules exposed it)
+- Parse the `offload_meters` list (smart-shedder module ids) on offload-capable
+  modules
 
 ### Changed
 

--- a/fixtures/homestatus_91763b24c43d3e344f424e8b.json
+++ b/fixtures/homestatus_91763b24c43d3e344f424e8b.json
@@ -234,6 +234,7 @@
           "type": "NLP",
           "on": true,
           "offload": false,
+          "offload_meters": ["98:76:54:32:10:ab"],
           "firmware_revision": 62,
           "last_seen": 1644569425,
           "power": 0,

--- a/fixtures/homestatus_91763b24c43d3e344f424e8b.json
+++ b/fixtures/homestatus_91763b24c43d3e344f424e8b.json
@@ -224,6 +224,7 @@
           "id": "12:34:56:80:60:40",
           "type": "NLG",
           "offload": false,
+          "offload_meters": [],
           "firmware_revision": 211,
           "last_seen": 1644567372,
           "wifi_strength": 51,

--- a/src/pyatmo/modules/module.py
+++ b/src/pyatmo/modules/module.py
@@ -380,6 +380,7 @@ class OffloadMixin(EntityBase):
 
         super().__init__(home, module)
         self.offload: bool | None = None
+        self.offload_meters: list[str] | None = None
 
 
 class SwitchMixin(EntityBase):

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -15,6 +15,12 @@ async def test_async_switch_NLP(async_home):
     assert module.power == 0
 
 
+async def test_offload_meters(async_home):
+    """offload_meters (smart-shedder ids) are parsed on offload modules."""
+    module = async_home.modules["12:34:56:80:00:12:ac:f2"]
+    assert module.offload_meters == ["98:76:54:32:10:ab"]
+
+
 async def test_async_switch_NLF(async_home):
     """Test NLF Legrand dimmer."""
     module_id = "00:11:22:33:00:11:45:fe"

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -21,6 +21,18 @@ async def test_offload_meters(async_home):
     assert module.offload_meters == ["98:76:54:32:10:ab"]
 
 
+async def test_offload_meters_absent(async_home):
+    """offload_meters is None when the field is absent from the response."""
+    module = async_home.modules["12:34:56:00:01:01:01:b7"]
+    assert module.offload_meters is None
+
+
+async def test_offload_meters_empty(async_home):
+    """offload_meters is an empty list when the API reports no shedders."""
+    module = async_home.modules["12:34:56:80:60:40"]
+    assert module.offload_meters == []
+
+
 async def test_async_switch_NLF(async_home):
     """Test NLF Legrand dimmer."""
     module_id = "00:11:22:33:00:11:45:fe"


### PR DESCRIPTION
## Summary by Sourcery

Parse and expose offload_meters on offload-capable modules and document and test the new field.

New Features:
- Expose parsed offload_meters (smart-shedder module IDs) on offload-capable modules.

Documentation:
- Document parsing of offload_meters for offload-capable modules in the changelog.

Tests:
- Add a test verifying offload_meters are correctly parsed for an offload module.