### PR TITLE
feat: parse last_seen for all modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Retry requests on Netatmo 429 concurrency errors (code 11) with exponential
   backoff, honoring the response `Retry-After` header when present (#547)
+- Parse the `last_seen` availability timestamp for all modules (previously only
+  VELUX modules exposed it)
 
 ### Changed
 

--- a/fixtures/homestatus_91763b24c43d3e344f424e8b.json
+++ b/fixtures/homestatus_91763b24c43d3e344f424e8b.json
@@ -62,6 +62,7 @@
         },
         {
           "id": "12:34:56:00:01:ae",
+          "last_seen": 1776675797,
           "reachable": true,
           "type": "NATherm1",
           "firmware_revision": 65,

--- a/src/pyatmo/modules/module.py
+++ b/src/pyatmo/modules/module.py
@@ -61,6 +61,7 @@ ATTRIBUTE_FILTER = {
     "history_features_values",
     "appliance_type",
     "doortag_category",
+    "last_seen",
 }
 
 
@@ -1260,6 +1261,7 @@ class Module(NetatmoBase):
 
     modules: list[str] | None
     reachable: bool | None
+    last_seen: int | None
     features: set[str]
 
     def __init__(self, home: Home, module: ModuleT) -> None:
@@ -1272,6 +1274,7 @@ class Module(NetatmoBase):
         self.home = home
         self.room_id = module.get("room_id")
         self.reachable = module.get("reachable")
+        self.last_seen = module.get("last_seen")
         self.bridge = module.get("bridge")
         self.modules = module.get("modules_bridged")
         self.device_category = DEVICE_CATEGORY_MAP.get(self.device_type)

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -137,6 +137,18 @@ async def test_async_climate_initial_state(async_account):
     assert isinstance(module, NATherm1)
 
 
+async def test_async_climate_last_seen(async_account):
+    """last_seen is parsed for non-VELUX modules."""
+    home_id = "91763b24c43d3e344f424e8b"
+    await async_account.async_update_status(home_id)
+    home = async_account.homes[home_id]
+
+    module = home.modules["12:34:56:00:01:ae"]
+    assert module.last_seen == 1776675797
+    # availability metadata, not a measurement feature
+    assert "last_seen" not in module.features
+
+
 async def test_async_climate_disconnected_state(async_account):
     """Test climate state when disconnected."""
     home_id = "91763b24c43d3e344f424e8b"


### PR DESCRIPTION
## Summary by Sourcery

Parse and expose the `last_seen` availability timestamp for all modules and validate it for climate modules.

New Features:
- Add `last_seen` as a parsed field on modules, making the availability timestamp accessible across module types.

Documentation:
- Update the changelog to document `last_seen` parsing for all modules.

Tests:
- Add a climate module test to verify `last_seen` parsing and confirm it is treated as availability metadata rather than a standard feature.