### PR TITLE
feat: parse OTH boiler diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   VELUX modules exposed it)
 - Parse the `offload_meters` list (smart-shedder module ids) on offload-capable
   modules
-- Parse OpenTherm boiler diagnostics on OTH modules (`boiler_control`,
-  `boiler_error`, `dhw_control`) and expose `boiler_status`
+- Parse OpenTherm boiler diagnostics on OTH modules as typed enums
+  (`boiler_control`, `boiler_error`, `dhw_control`) and expose `boiler_status`;
+  unknown values fall back to `unknown` instead of breaking parsing
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   VELUX modules exposed it)
 - Parse the `offload_meters` list (smart-shedder module ids) on offload-capable
   modules
+- Parse OpenTherm boiler diagnostics on OTH modules (`boiler_control`,
+  `boiler_error`, `dhw_control`) and expose `boiler_status`
 
 ### Changed
 

--- a/fixtures/homestatus_91763b24c43d3e344f424e8b.json
+++ b/fixtures/homestatus_91763b24c43d3e344f424e8b.json
@@ -137,6 +137,7 @@
         },
         {
           "boiler_control": "onoff",
+          "boiler_error": "water_pressure",
           "dhw_control": "none",
           "firmware_revision": 22,
           "hardware_version": 222,

--- a/src/pyatmo/modules/base_class.py
+++ b/src/pyatmo/modules/base_class.py
@@ -12,7 +12,14 @@ from typing import TYPE_CHECKING, Any
 
 from pyatmo.const import GPS_COORDINATES_COUNT, MAX_HISTORY_TIME_FRAME, RawData
 from pyatmo.event import EventTypes
-from pyatmo.modules.device_types import ApplianceType, DeviceType, DoorTagCategory
+from pyatmo.modules.device_types import (
+    ApplianceType,
+    BoilerControl,
+    BoilerError,
+    DeviceType,
+    DhwControl,
+    DoorTagCategory,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterator
@@ -36,6 +43,17 @@ NETATMO_ATTRIBUTES_MAP: dict[str, Callable[[dict[str, Any], Any], Any]] = {
     "target_position__step": lambda x, _: x.get("target_position:step"),
     "appliance_type": lambda x, y: ApplianceType(x.get("appliance_type", y)),
     "doortag_category": lambda x, y: DoorTagCategory(x.get("category", y)),
+    # Coerce only when present so absent fields keep their default (no spurious
+    # "unknown" warning from Enum(None) on every non-OTH update).
+    "boiler_control": lambda x, y: (
+        BoilerControl(x["boiler_control"]) if "boiler_control" in x else y
+    ),
+    "boiler_error": lambda x, y: (
+        BoilerError(x["boiler_error"]) if "boiler_error" in x else y
+    ),
+    "dhw_control": lambda x, y: (
+        DhwControl(x["dhw_control"]) if "dhw_control" in x else y
+    ),
 }
 
 

--- a/src/pyatmo/modules/device_types.py
+++ b/src/pyatmo/modules/device_types.py
@@ -351,3 +351,57 @@ class DoorTagCategory(StrEnum):
         msg: str = f"{key} category is unknown"
         LOG.warning(msg)
         return DoorTagCategory.unknown
+
+
+class BoilerControl(StrEnum):
+    """Boiler control mode reported by an OpenTherm gateway (OTH)."""
+
+    onoff = "onoff"
+    opentherm = "opentherm"
+    detecting = "detecting"
+    unknown = "unknown"
+
+    @classmethod
+    def _missing_(cls, key: object) -> Literal[BoilerControl.unknown]:
+        """Handle unknown boiler control values."""
+
+        msg: str = f"{key} boiler control is unknown"
+        LOG.warning(msg)
+        return BoilerControl.unknown
+
+
+class BoilerError(StrEnum):
+    """Boiler error reported by an OpenTherm gateway (OTH)."""
+
+    boiler_not_responding = "boiler_not_responding"
+    maintenance = "maintenance"
+    water_pressure = "water_pressure"
+    boiler_flame = "boiler_flame"
+    air_pressure = "air_pressure"
+    boiler_temperature = "boiler_temperature"
+    unknown = "unknown"
+
+    @classmethod
+    def _missing_(cls, key: object) -> Literal[BoilerError.unknown]:
+        """Handle unknown boiler error values."""
+
+        msg: str = f"{key} boiler error is unknown"
+        LOG.warning(msg)
+        return BoilerError.unknown
+
+
+class DhwControl(StrEnum):
+    """Domestic-hot-water control reported by an OpenTherm gateway (OTH)."""
+
+    none = "none"
+    instantaneous = "instantaneous"
+    water_tank = "water_tank"
+    unknown = "unknown"
+
+    @classmethod
+    def _missing_(cls, key: object) -> Literal[DhwControl.unknown]:
+        """Handle unknown domestic-hot-water control values."""
+
+        msg: str = f"{key} dhw control is unknown"
+        LOG.warning(msg)
+        return DhwControl.unknown

--- a/src/pyatmo/modules/module.py
+++ b/src/pyatmo/modules/module.py
@@ -244,6 +244,18 @@ class BoilerMixin(EntityBase):
         self.boiler_valve_comfort_boost: bool | None = None
 
 
+class OpenThermMixin(EntityBase):
+    """Mixin for OpenTherm boiler diagnostics (OTH)."""
+
+    def __init__(self, home: Home, module: ModuleT) -> None:
+        """Initialize OpenTherm mixin."""
+
+        super().__init__(home, module)
+        self.boiler_control: str | None = None  # onoff | opentherm | detecting
+        self.boiler_error: str | None = None
+        self.dhw_control: str | None = None  # none | instantaneous | water_tank
+
+
 class CoolerMixin(EntityBase):
     """Mixin for cooler data."""
 

--- a/src/pyatmo/modules/module.py
+++ b/src/pyatmo/modules/module.py
@@ -23,8 +23,11 @@ from pyatmo.modules.base_class import EntityBase, NetatmoBase, Place, update_nam
 from pyatmo.modules.device_types import (
     DEVICE_CATEGORY_MAP,
     ApplianceType,
+    BoilerControl,
+    BoilerError,
     DeviceCategory,
     DeviceType,
+    DhwControl,
     DoorTagCategory,
 )
 from pyatmo.webrtc import WebRTCAnswer, WebRTCStream
@@ -62,6 +65,9 @@ ATTRIBUTE_FILTER = {
     "appliance_type",
     "doortag_category",
     "last_seen",
+    "boiler_control",
+    "boiler_error",
+    "dhw_control",
 }
 
 
@@ -251,9 +257,9 @@ class OpenThermMixin(EntityBase):
         """Initialize OpenTherm mixin."""
 
         super().__init__(home, module)
-        self.boiler_control: str | None = None  # onoff | opentherm | detecting
-        self.boiler_error: str | None = None
-        self.dhw_control: str | None = None  # none | instantaneous | water_tank
+        self.boiler_control: BoilerControl | None = None
+        self.boiler_error: BoilerError | None = None
+        self.dhw_control: DhwControl | None = None
 
 
 class CoolerMixin(EntityBase):

--- a/src/pyatmo/modules/netatmo.py
+++ b/src/pyatmo/modules/netatmo.py
@@ -33,6 +33,7 @@ from pyatmo.modules.module import (
     Module,
     MonitoringMixin,
     NoiseMixin,
+    OpenThermMixin,
     PlaceMixin,
     PressureMixin,
     RainMixin,
@@ -64,7 +65,7 @@ class NAPlug(FirmwareMixin, RfMixin, WifiMixin, Module):
     """Class to represent a Netatmo NAPlug."""
 
 
-class OTH(FirmwareMixin, WifiMixin, Module):
+class OTH(FirmwareMixin, WifiMixin, BoilerMixin, OpenThermMixin, Module):
     """Class to represent a Netatmo OTH."""
 
 

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -1,15 +1,22 @@
 """Define tests for climate module."""
 
 import json
-from unittest.mock import AsyncMock, patch
+import logging
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import anyio
 import pytest
 
 from pyatmo import DeviceType, NoScheduleError
 from pyatmo.modules import NATherm1
-from pyatmo.modules.device_types import DeviceCategory
+from pyatmo.modules.device_types import (
+    BoilerControl,
+    BoilerError,
+    DeviceCategory,
+    DhwControl,
+)
 from pyatmo.modules.module import BoilerMixin, OpenThermMixin
+from pyatmo.modules.netatmo import OTH
 from tests.common import MockResponse, fake_post_request
 from tests.conftest import does_not_raise
 
@@ -99,11 +106,43 @@ async def test_async_climate_OTH(async_home):
     assert len(module.modules) == 1
     assert module.wifi_strength == 57
     assert module.firmware_revision == 22
+    # coerced to enums, still string-comparable (StrEnum)
+    assert module.boiler_control is BoilerControl.onoff
+    assert module.boiler_error is BoilerError.water_pressure
+    assert module.dhw_control is DhwControl.none
     assert module.boiler_control == "onoff"
     assert module.boiler_error == "water_pressure"
     assert module.dhw_control == "none"
     # BoilerMixin field is now parsed; defaults to None when absent from the response
     assert module.boiler_status is None
+
+
+async def test_oth_boiler_enum_unknown_value():
+    """Unknown enum values fall back to `unknown` instead of crashing parsing."""
+    module = OTH(MagicMock(), {"id": "x", "type": "OTH"})
+    module.update_topology(
+        {
+            "id": "x",
+            "type": "OTH",
+            "boiler_control": "brand_new_value",
+            "boiler_error": "brand_new_error",
+            "dhw_control": "brand_new_mode",
+        },
+    )
+    assert module.boiler_control is BoilerControl.unknown
+    assert module.boiler_error is BoilerError.unknown
+    assert module.dhw_control is DhwControl.unknown
+
+
+async def test_oth_boiler_enum_absent_no_warning(caplog):
+    """Absent boiler fields stay None and do not log spurious 'unknown' warnings."""
+    module = OTH(MagicMock(), {"id": "x", "type": "OTH"})
+    with caplog.at_level(logging.WARNING):
+        module.update_topology({"id": "x", "type": "OTH"})
+    assert module.boiler_control is None
+    assert module.boiler_error is None
+    assert module.dhw_control is None
+    assert "unknown" not in caplog.text.lower()
 
 
 async def test_async_climate_OTH_mixin_composition(async_home):

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -9,6 +9,7 @@ import pytest
 from pyatmo import DeviceType, NoScheduleError
 from pyatmo.modules import NATherm1
 from pyatmo.modules.device_types import DeviceCategory
+from pyatmo.modules.module import BoilerMixin, OpenThermMixin
 from tests.common import MockResponse, fake_post_request
 from tests.conftest import does_not_raise
 
@@ -103,6 +104,20 @@ async def test_async_climate_OTH(async_home):
     assert module.dhw_control == "none"
     # BoilerMixin field is now parsed; defaults to None when absent from the response
     assert module.boiler_status is None
+
+
+async def test_async_climate_OTH_mixin_composition(async_home):
+    """Guard the OTH MRO: both boiler mixins run and no diagnostic field is skipped.
+
+    Protects against reordering the OTH base classes, which could silently drop
+    a mixin from the cooperative ``super().__init__`` chain.
+    """
+    module = async_home.modules["12:34:56:20:f5:44"]
+    assert isinstance(module, BoilerMixin)
+    assert isinstance(module, OpenThermMixin)
+    # every diagnostic field is initialised regardless of response content
+    for attr in ("boiler_control", "boiler_error", "dhw_control", "boiler_status"):
+        assert hasattr(module, attr)
 
 
 async def test_async_climate_BNS(async_home):

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -98,6 +98,11 @@ async def test_async_climate_OTH(async_home):
     assert len(module.modules) == 1
     assert module.wifi_strength == 57
     assert module.firmware_revision == 22
+    assert module.boiler_control == "onoff"
+    assert module.boiler_error == "water_pressure"
+    assert module.dhw_control == "none"
+    # BoilerMixin field is now parsed; defaults to None when absent from the response
+    assert module.boiler_status is None
 
 
 async def test_async_climate_BNS(async_home):


### PR DESCRIPTION
## Summary by Sourcery

Add OpenTherm boiler diagnostics support for OTH modules and document the new exposed fields.

New Features:
- Expose OpenTherm boiler diagnostic fields (`boiler_control`, `boiler_error`, `dhw_control`) and `boiler_status` on OTH modules.

Documentation:
- Update changelog to document OpenTherm boiler diagnostics parsing and newly exposed boiler fields.

Tests:
- Extend climate tests to cover OpenTherm boiler diagnostic fields on OTH modules.