### PR TITLE
feat: surface per-module error code from homestatus errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Parse OpenTherm boiler diagnostics on OTH modules as typed enums
   (`boiler_control`, `boiler_error`, `dhw_control`) and expose `boiler_status`;
   unknown values fall back to `unknown` instead of breaking parsing
+- Surface the per-module error `code` from the `/homestatus` `errors[]` array as
+  `Module.error_code`, and log a warning for errors on unknown module ids
 
 ### Changed
 

--- a/src/pyatmo/home.py
+++ b/src/pyatmo/home.py
@@ -188,6 +188,10 @@ class Home:
             if module["id"] not in self.modules:
                 self.update_topology({"modules": [module]})
             await self.modules[module["id"]].update(module)
+            # Clear any error code from a previous /homestatus errors[] entry:
+            # the module is reported healthy again. Reflection in update() would
+            # otherwise carry the stale code forward (raw data has no error_code).
+            self.modules[module["id"]].error_code = None
 
         for room in data.get("rooms", []):
             has_an_update = True

--- a/src/pyatmo/home.py
+++ b/src/pyatmo/home.py
@@ -168,7 +168,17 @@ class Home:
         has_error = False
         for module in raw_data.get("errors", []):
             has_error = True
-            await self.modules[module["id"]].update({})
+            module_id = module["id"]
+            if module_id in self.modules:
+                await self.modules[module_id].update({})
+                # Set error_code AFTER update({}): update() reruns reflection
+                # (_update_attributes) which would otherwise reset it to None.
+                self.modules[module_id].error_code = module.get("code")
+            else:
+                LOG.warning(
+                    "Error reported for unknown module id (%s); skipping",
+                    module_id,
+                )
 
         data = raw_data["home"]
 

--- a/src/pyatmo/modules/module.py
+++ b/src/pyatmo/modules/module.py
@@ -68,6 +68,7 @@ ATTRIBUTE_FILTER = {
     "boiler_control",
     "boiler_error",
     "dhw_control",
+    "error_code",
 }
 
 
@@ -1281,6 +1282,7 @@ class Module(NetatmoBase):
     modules: list[str] | None
     reachable: bool | None
     last_seen: int | None
+    error_code: int | None
     features: set[str]
 
     def __init__(self, home: Home, module: ModuleT) -> None:
@@ -1294,6 +1296,7 @@ class Module(NetatmoBase):
         self.room_id = module.get("room_id")
         self.reachable = module.get("reachable")
         self.last_seen = module.get("last_seen")
+        self.error_code = None
         self.bridge = module.get("bridge")
         self.modules = module.get("modules_bridged")
         self.device_category = DEVICE_CATEGORY_MAP.get(self.device_type)

--- a/tests/test_home.py
+++ b/tests/test_home.py
@@ -244,6 +244,34 @@ async def test_home_event_update(async_account):
     assert events[1].event_type == "connection"
 
 
+async def test_async_home_module_error_code(async_account):
+    """Test that per-module error code from homestatus errors[] is surfaced."""
+    home_id = "91763b24c43d3e344f424e8b"
+    await async_account.async_update_status(home_id)
+    home = async_account.homes[home_id]
+
+    module_id = "12:34:56:00:fa:d0"
+    assert module_id in home.modules
+    module = home.modules[module_id]
+
+    async with await anyio.open_file(
+        "fixtures/home_status_error_disconnected.json",
+        encoding="utf-8",
+    ) as json_file:
+        home_status_fixture = json.loads(await json_file.read())
+    mock_home_status_resp = MockResponse(home_status_fixture, 200)
+
+    with patch(
+        "pyatmo.auth.AbstractAsyncAuth.async_post_api_request",
+        AsyncMock(return_value=mock_home_status_resp),
+    ) as mock_request:
+        await async_account.async_update_status(home_id)
+        mock_request.assert_called()
+
+    assert module.error_code == 6
+    assert "error_code" not in module.features
+
+
 def test_device_types_missing():
     """Test handling of missing device types."""
 

--- a/tests/test_home.py
+++ b/tests/test_home.py
@@ -271,6 +271,11 @@ async def test_async_home_module_error_code(async_account):
     assert module.error_code == 6
     assert "error_code" not in module.features
 
+    # Recovery: a subsequent healthy /homestatus update (the module is reported
+    # in home.modules again) must clear the stale error code back to None.
+    await async_account.async_update_status(home_id)
+    assert module.error_code is None
+
 
 def test_device_types_missing():
     """Test handling of missing device types."""


### PR DESCRIPTION
## Summary by Sourcery

Surface per-module error codes from homestatus errors and expose them on Module instances.

New Features:
- Expose per-module error code from /homestatus errors[] as Module.error_code.

Enhancements:
- Ignore and log homestatus errors that reference unknown module ids.

Documentation:
- Update changelog to document the new Module.error_code exposure and handling of unknown module error ids.

Tests:
- Add a test verifying that module-specific error codes are set on modules and not mixed into generic features.