### PR TITLE
feat: surface more /homesdata topology fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,16 +20,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   unknown values fall back to `unknown` instead of breaking parsing
 - Surface the per-module error `code` from the `/homestatus` `errors[]` array as
   `Module.error_code`, and log a warning for errors on unknown module ids
+- Parse the module `setup_date` (install timestamp) from the `/homesdata`
+  topology for all module types
+- Parse the room `type` (as `Room.room_type`) and `therm_relay` (id of the
+  controlling heating module) from the `/homesdata` topology
+- Parse the user `country` and `pending_user_consent` from `/homesdata` into
+  `AsyncAccount.user_country` and `AsyncAccount.pending_user_consent`
 
 ### Changed
 
--
+- Clarify the room setpoint-mode/pilot-wire lookup: replace the misleadingly
+  named "invert" dicts with `climate_setpoint_mode_to_pilot_wire` /
+  `pilot_wire_to_climate_setpoint_mode` helpers that centralize the shared
+  frost-guard fallback
 
 ### Fixed
 
 - Exclude `doortag_category` from the `NACamDoorTag` `features` set, matching the
   handling of the sibling metadata attributes `device_category` and `appliance_type`
   (#500)
+- `AsyncAccount.user` (email) was always `None` because `extract_raw_data` dropped
+  the `/homesdata` `user` object; the user block is now carried through and the
+  email populated
 
 ### Removed
 

--- a/fixtures/homesdata.json
+++ b/fixtures/homesdata.json
@@ -1009,6 +1009,8 @@
       "unit_wind": 0,
       "all_linked": false,
       "type": "netatmo",
+      "country": "DE",
+      "pending_user_consent": true,
       "id": "91763b24c43d3e344f424e8b"
     }
   },

--- a/src/pyatmo/__init__.py
+++ b/src/pyatmo/__init__.py
@@ -21,6 +21,7 @@ from pyatmo.room import Room
 from pyatmo.webrtc import WebRTCStream
 
 __all__: list[str] = [
+    "SIREN_BASE_URL",
     "AbstractAsyncAuth",
     "ApiError",
     "ApiHomeReachabilityError",
@@ -35,7 +36,6 @@ __all__: list[str] = [
     "NoDeviceError",
     "NoScheduleError",
     "Room",
-    "SIREN_BASE_URL",
     "WebRTCStream",
     "const",
     "modules",

--- a/src/pyatmo/account.py
+++ b/src/pyatmo/account.py
@@ -88,9 +88,13 @@ class AsyncAccount:
         resp = await self.auth.async_post_api_request(
             endpoint=GETHOMESDATA_ENDPOINT,
         )
-        self.raw_data = extract_raw_data(await resp.json(), "homes")
+        body = await resp.json()
+        self.raw_data = extract_raw_data(body, "homes")
 
-        user = self.raw_data.get("user", {})
+        # Read the user block straight from the response body; keep it out of
+        # raw_data so consumers that serialize raw_data (e.g. Home Assistant
+        # diagnostics) do not leak the user's email/id.
+        user = body.get("body", {}).get("user", {})
         self.user = user.get("email")
         self.user_country = user.get("country")
         self.pending_user_consent = user.get("pending_user_consent")

--- a/src/pyatmo/account.py
+++ b/src/pyatmo/account.py
@@ -42,6 +42,8 @@ class AsyncAccount:
 
         self.auth: AbstractAsyncAuth = auth
         self.user: str | None = None
+        self.user_country: str | None = None
+        self.pending_user_consent: bool | None = None
         self.all_homes_id: dict[str, str] = {}
         self.homes: dict[str, Home] = {}
         self.raw_data: RawData = {}
@@ -88,7 +90,10 @@ class AsyncAccount:
         )
         self.raw_data = extract_raw_data(await resp.json(), "homes")
 
-        self.user = self.raw_data.get("user", {}).get("email")
+        user = self.raw_data.get("user", {})
+        self.user = user.get("email")
+        self.user_country = user.get("country")
+        self.pending_user_consent = user.get("pending_user_consent")
 
         self.process_topology(disabled_homes_ids=disabled_homes_ids)
 

--- a/src/pyatmo/helpers.py
+++ b/src/pyatmo/helpers.py
@@ -51,6 +51,7 @@ def extract_raw_data(resp: RawData, tag: str) -> RawData:
             raise NoDeviceError(msg)
         return {
             tag: homes,
+            "user": resp["body"].get("user", {}),
             "errors": resp["body"].get("errors", []),
         }
 

--- a/src/pyatmo/helpers.py
+++ b/src/pyatmo/helpers.py
@@ -51,7 +51,6 @@ def extract_raw_data(resp: RawData, tag: str) -> RawData:
             raise NoDeviceError(msg)
         return {
             tag: homes,
-            "user": resp["body"].get("user", {}),
             "errors": resp["body"].get("errors", []),
         }
 

--- a/src/pyatmo/modules/module.py
+++ b/src/pyatmo/modules/module.py
@@ -65,6 +65,7 @@ ATTRIBUTE_FILTER = {
     "appliance_type",
     "doortag_category",
     "last_seen",
+    "setup_date",
     "boiler_control",
     "boiler_error",
     "dhw_control",
@@ -1282,6 +1283,7 @@ class Module(NetatmoBase):
     modules: list[str] | None
     reachable: bool | None
     last_seen: int | None
+    setup_date: int | None
     error_code: int | None
     features: set[str]
 
@@ -1296,6 +1298,7 @@ class Module(NetatmoBase):
         self.room_id = module.get("room_id")
         self.reachable = module.get("reachable")
         self.last_seen = module.get("last_seen")
+        self.setup_date = module.get("setup_date")
         self.error_code = None
         self.bridge = module.get("bridge")
         self.modules = module.get("modules_bridged")

--- a/src/pyatmo/room.py
+++ b/src/pyatmo/room.py
@@ -119,6 +119,10 @@ class Room(NetatmoBase):
 
     radiators_power: int | None = None
 
+    # /homesdata topology fields
+    room_type: str | None = None  # API "type": kitchen, bedroom, livingroom, ...
+    therm_relay: str | None = None  # main device id of the controlling heating module
+
     def __init__(
         self,
         home: Home,
@@ -130,6 +134,8 @@ class Room(NetatmoBase):
         super().__init__(room)
         self.home = home
         self.support_pilot_wire = False
+        self.room_type = room.get("type")
+        self.therm_relay = room.get("therm_relay")
         self.modules = {
             m_id: m
             for m_id, m in all_modules.items()
@@ -143,6 +149,8 @@ class Room(NetatmoBase):
         """Update room topology."""
 
         self.name = raw_data.get("name", UNKNOWN)
+        self.room_type = raw_data.get("type", self.room_type)
+        self.therm_relay = raw_data.get("therm_relay", self.therm_relay)
         self.modules = {
             m_id: m
             for m_id, m in self.home.modules.items()

--- a/src/pyatmo/room.py
+++ b/src/pyatmo/room.py
@@ -40,8 +40,9 @@ LOG: logging.Logger = logging.getLogger(__name__)
 
 MODE_MAP: dict[str, str] = {SCHEDULE: HOME}
 
-# as for now all the below is not exposed at all through the API, don't put it in the public API, so not in const.py
-NETAMO_CLIMATE_SETPOINT_MODE_TO_PILOT_WIRE: dict[str, str] = {
+# Climate setpoint mode -> pilot-wire ("fil pilote") preset.
+# Many-to-one: several modes collapse onto PILOT_WIRE_COMFORT.
+_CLIMATE_SETPOINT_MODE_TO_PILOT_WIRE: dict[str, str] = {
     MANUAL: PILOT_WIRE_COMFORT,
     MAX: PILOT_WIRE_COMFORT,
     OFF: PILOT_WIRE_FROST_GUARD,
@@ -50,8 +51,12 @@ NETAMO_CLIMATE_SETPOINT_MODE_TO_PILOT_WIRE: dict[str, str] = {
     SCHEDULE: PILOT_WIRE_COMFORT,
     AWAY: PILOT_WIRE_AWAY,
 }
-# invert of the map above:
-NETAMO_PILOT_WIRE_TO_CLIMATE_SETPOINT_MODE: dict[str, str] = {
+
+# Pilot-wire preset -> canonical NLC climate setpoint mode. Not the inverse of
+# the map above: it picks one canonical mode per preset and also covers presets
+# the forward map never emits (COMFORT_1, COMFORT_2, STAND_BY) that can arrive
+# straight from the API.
+_PILOT_WIRE_TO_CLIMATE_SETPOINT_MODE: dict[str, str] = {
     PILOT_WIRE_COMFORT: MANUAL,
     PILOT_WIRE_AWAY: MANUAL,  # AWAY is like ECO for a pilot wire heater, so put manual to force it to happen
     PILOT_WIRE_FROST_GUARD: FROSTGUARD,
@@ -59,6 +64,16 @@ NETAMO_PILOT_WIRE_TO_CLIMATE_SETPOINT_MODE: dict[str, str] = {
     PILOT_WIRE_COMFORT_1: HOME,
     PILOT_WIRE_COMFORT_2: HOME,
 }
+
+
+def climate_setpoint_mode_to_pilot_wire(mode: str) -> str:
+    """Map a climate setpoint mode to its pilot-wire preset (frost guard default)."""
+    return _CLIMATE_SETPOINT_MODE_TO_PILOT_WIRE.get(mode, PILOT_WIRE_FROST_GUARD)
+
+
+def pilot_wire_to_climate_setpoint_mode(pilot_wire: str) -> str:
+    """Map a pilot-wire preset back to the canonical NLC setpoint mode (frost guard default)."""
+    return _PILOT_WIRE_TO_CLIMATE_SETPOINT_MODE.get(pilot_wire, FROSTGUARD)
 
 
 @dataclass
@@ -80,29 +95,6 @@ class Room(NetatmoBase):
     therm_setpoint_temperature: float | None = None
 
     therm_setpoint_mode: str | None = None
-    # therm_setpoint_mode: per the documentation: "The thermostat mode in which the room is.
-    # For a room controlled by a BNS, mode can be home, manual, max or hg/off (if heating/cooling).
-    # For a room controlled by a NLC, mode can be off, manual or hg."
-    # values can be
-    # "manual"
-    # "max"
-    # "off"
-    # "home"
-    # "hg"
-    # "schedule"
-    # "away"
-
-    # therm_setpoint_fp: used to set up pilot wire, ie "fil pilote" set point
-    # netatmo documentation:
-    # Usually used to control (Fil pilote (FP)) setpoint
-    # values:
-    # "comfort"
-    # "away"
-    # "frost_guard"
-    # "stand_by"
-    # "comfort_1" => documentation unclear and contradictory here, as it is in the json schema but no in the doc
-    # "comfort_2" => same
-    # but here:
     therm_setpoint_fp: str | None = None
     support_pilot_wire: bool = False
 
@@ -119,7 +111,6 @@ class Room(NetatmoBase):
 
     radiators_power: int | None = None
 
-    # /homesdata topology fields
     room_type: str | None = None  # API "type": kitchen, bedroom, livingroom, ...
     therm_relay: str | None = None  # main device id of the controlling heating module
 
@@ -295,17 +286,11 @@ class Room(NetatmoBase):
             # in case both are None stop everything
             if mode is None:
                 mode = FROSTGUARD
-            pilot_wire = NETAMO_CLIMATE_SETPOINT_MODE_TO_PILOT_WIRE.get(
-                mode,
-                PILOT_WIRE_FROST_GUARD,
-            )
+            pilot_wire = climate_setpoint_mode_to_pilot_wire(mode)
             # force back the proper preset mode in case of pilot wire
             # to comply with netatmo model
             if self.support_pilot_wire and self.climate_type == DeviceType.NLC:
-                mode = NETAMO_PILOT_WIRE_TO_CLIMATE_SETPOINT_MODE.get(
-                    pilot_wire,
-                    FROSTGUARD,
-                )
+                mode = pilot_wire_to_climate_setpoint_mode(pilot_wire)
 
         if pilot_wire is not None and mode is None:
             mode = MANUAL
@@ -321,27 +306,21 @@ class Room(NetatmoBase):
             "therm",
         )
 
-        json_therm_set: dict[str, Any] = {
-            "rooms": [
-                {
-                    "id": self.entity_id,
-                    f"{setpoint_mode_prefix}_setpoint_mode": mode,
-                },
-            ],
+        room_payload: dict[str, Any] = {
+            "id": self.entity_id,
+            f"{setpoint_mode_prefix}_setpoint_mode": mode,
         }
 
         if temp:
-            json_therm_set["rooms"][0][
-                f"{setpoint_mode_prefix}_setpoint_temperature"
-            ] = temp
+            room_payload[f"{setpoint_mode_prefix}_setpoint_temperature"] = temp
 
         if end_time:
-            json_therm_set["rooms"][0][f"{setpoint_mode_prefix}_setpoint_end_time"] = (
-                end_time
-            )
+            room_payload[f"{setpoint_mode_prefix}_setpoint_end_time"] = end_time
 
         if self.support_pilot_wire and pilot_wire:
-            json_therm_set["rooms"][0]["therm_setpoint_fp"] = pilot_wire
+            room_payload["therm_setpoint_fp"] = pilot_wire
+
+        json_therm_set: dict[str, Any] = {"rooms": [room_payload]}
 
         return await self.home.async_set_state(json_therm_set)
 

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import anyio
 import pytest
 
-from pyatmo import DeviceType, NoScheduleError
+from pyatmo import DeviceType, NoScheduleError, const
 from pyatmo.modules import NATherm1
 from pyatmo.modules.device_types import (
     BoilerControl,
@@ -17,6 +17,10 @@ from pyatmo.modules.device_types import (
 )
 from pyatmo.modules.module import BoilerMixin, OpenThermMixin
 from pyatmo.modules.netatmo import OTH
+from pyatmo.room import (
+    climate_setpoint_mode_to_pilot_wire,
+    pilot_wire_to_climate_setpoint_mode,
+)
 from tests.common import MockResponse, fake_post_request
 from tests.conftest import does_not_raise
 
@@ -479,3 +483,40 @@ async def test_power_wire(async_home_multi):
     assert room.climate_type == DeviceType.NLC
     assert DeviceType.NLC in room.device_types
     assert room.support_pilot_wire is True
+
+
+@pytest.mark.parametrize(
+    ("mode", "expected"),
+    [
+        (const.MANUAL, const.PILOT_WIRE_COMFORT),
+        (const.MAX, const.PILOT_WIRE_COMFORT),
+        (const.OFF, const.PILOT_WIRE_FROST_GUARD),
+        (const.HOME, const.PILOT_WIRE_COMFORT),
+        (const.FROSTGUARD, const.PILOT_WIRE_FROST_GUARD),
+        (const.SCHEDULE, const.PILOT_WIRE_COMFORT),
+        (const.AWAY, const.PILOT_WIRE_AWAY),
+        # unknown mode falls back to frost guard
+        ("nonsense", const.PILOT_WIRE_FROST_GUARD),
+    ],
+)
+def test_climate_setpoint_mode_to_pilot_wire(mode, expected):
+    """Test climate setpoint mode -> pilot wire preset mapping (frost-guard default)."""
+    assert climate_setpoint_mode_to_pilot_wire(mode) == expected
+
+
+@pytest.mark.parametrize(
+    ("pilot_wire", "expected"),
+    [
+        (const.PILOT_WIRE_COMFORT, const.MANUAL),
+        (const.PILOT_WIRE_AWAY, const.MANUAL),
+        (const.PILOT_WIRE_FROST_GUARD, const.FROSTGUARD),
+        (const.PILOT_WIRE_STAND_BY, const.FROSTGUARD),
+        (const.PILOT_WIRE_COMFORT_1, const.HOME),
+        (const.PILOT_WIRE_COMFORT_2, const.HOME),
+        # unknown pilot wire preset falls back to frost guard
+        ("nonsense", const.FROSTGUARD),
+    ],
+)
+def test_pilot_wire_to_climate_setpoint_mode(pilot_wire, expected):
+    """Test pilot wire preset -> canonical NLC setpoint mode mapping (frost-guard default)."""
+    assert pilot_wire_to_climate_setpoint_mode(pilot_wire) == expected

--- a/tests/test_home.py
+++ b/tests/test_home.py
@@ -305,6 +305,10 @@ async def test_async_account_user_country_and_consent(async_account):
     assert async_account.user_country == "DE"
     assert async_account.pending_user_consent is True
 
+    # The raw user block (email/id PII) must not leak into raw_data, which
+    # consumers such as Home Assistant diagnostics serialize wholesale.
+    assert "user" not in async_account.raw_data
+
 
 def test_device_types_missing():
     """Test handling of missing device types."""

--- a/tests/test_home.py
+++ b/tests/test_home.py
@@ -277,6 +277,35 @@ async def test_async_home_module_error_code(async_account):
     assert module.error_code is None
 
 
+async def test_async_home_module_setup_date(async_home):
+    """Test that module setup_date from /homesdata topology is surfaced."""
+    module_id = "12:34:56:00:fa:d0"
+    assert module_id in async_home.modules
+    module = async_home.modules[module_id]
+    assert module.setup_date == 1494963356
+    assert "setup_date" not in module.features
+
+
+async def test_async_home_room_type_and_therm_relay(async_home):
+    """Test room type + therm_relay from /homesdata topology are surfaced."""
+    livingroom = async_home.rooms["2746182631"]
+    assert livingroom.room_type == "livingroom"
+
+    bureau = async_home.rooms["222452125"]
+    assert bureau.room_type == "electrical_cabinet"
+    assert bureau.therm_relay == "12:34:56:20:f5:44"
+
+    # Rooms without therm_relay in the payload default to None.
+    assert livingroom.therm_relay is None
+
+
+async def test_async_account_user_country_and_consent(async_account):
+    """Test user country + pending_user_consent from /homesdata are surfaced."""
+    assert async_account.user == "john@doe.com"
+    assert async_account.user_country == "DE"
+    assert async_account.pending_user_consent is True
+
+
 def test_device_types_missing():
     """Test handling of missing device types."""
 


### PR DESCRIPTION
The topology parser dropped several fields the /homesdata response carries. Read them so consumers can access module install dates, room categorisation and user metadata.

## Summary by Sourcery

Expose additional /homesdata topology fields to consumers, including module setup metadata, room classification, and user information.

New Features:
- Surface module setup_date from /homesdata topology and make it available on Module instances.
- Expose room_type and therm_relay fields on Room objects derived from /homesdata topology.
- Expose user_country and pending_user_consent from /homesdata on Account instances.
- Export SIREN_BASE_URL as part of the public pyatmo package API.

Enhancements:
- Include user data from /homesdata in the raw topology extraction helper to support new account fields.

Tests:
- Add async home, room, and account tests validating exposure of setup_date, room_type, therm_relay, user_country, and pending_user_consent from /homesdata topology.