### PR TITLE
feat: parse electricity and event schedule variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   controlling heating module) from the `/homesdata` topology
 - Parse the user `country` and `pending_user_consent` from `/homesdata` into
   `AsyncAccount.user_country` and `AsyncAccount.pending_user_consent`
+- Parse the distinguishing payload of `electricity` / `electricity_production`
+  schedules (`tariff`, `tariff_option`, `power_threshold`, `contract_power_unit`
+  and per-zone `price_type` / `price_value`) and of `event` schedules
+  (`timetable_sunrise` / `timetable_sunset` twilight entries and per-zone module
+  actions), previously dropped when collapsed to a base `Schedule`
 
 ### Changed
 
@@ -40,8 +45,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   handling of the sibling metadata attributes `device_category` and `appliance_type`
   (#500)
 - `AsyncAccount.user` (email) was always `None` because `extract_raw_data` dropped
-  the `/homesdata` `user` object; the user block is now carried through and the
-  email populated
+  the `/homesdata` `user` object; the email is now read from the response body.
+  The raw `user` block is deliberately kept out of `AsyncAccount.raw_data` so
+  consumers that serialize it (e.g. Home Assistant diagnostics) do not leak the
+  user's email/id
 
 ### Removed
 

--- a/fixtures/homesdata.json
+++ b/fixtures/homesdata.json
@@ -962,6 +962,83 @@
             "name": "Winter",
             "id": "b1b54a2f45795764f59d50d8",
             "type": "therm"
+          },
+          {
+            "name": "Electricity",
+            "id": "c1c54a2f45795764f59d50d9",
+            "type": "electricity",
+            "tariff": "custom",
+            "tariff_option": "peak_and_off_peak",
+            "power_threshold": 6,
+            "contract_power_unit": "kVA",
+            "timetable": [
+              {
+                "zone_id": 0,
+                "m_offset": 0
+              }
+            ],
+            "zones": [
+              {
+                "id": 0,
+                "name": "Peak",
+                "type": 0,
+                "price_type": "peak",
+                "price_value": 0.21
+              },
+              {
+                "id": 1,
+                "name": "Off-peak",
+                "type": 1,
+                "price_type": "off_peak",
+                "price_value": 0.16
+              }
+            ]
+          },
+          {
+            "name": "Event",
+            "id": "d1d54a2f45795764f59d50da",
+            "type": "event",
+            "timetable_sunrise": [
+              {
+                "zone_id": 0,
+                "day": 1,
+                "twilight_offset": -30
+              }
+            ],
+            "timetable_sunset": [
+              {
+                "zone_id": 1,
+                "day": 1,
+                "twilight_offset": 15
+              }
+            ],
+            "zones": [
+              {
+                "id": 0,
+                "name": "Morning",
+                "type": 0,
+                "modules": [
+                  {
+                    "id": "12:34:56:00:01:ae",
+                    "bridge": "12:34:56:00:fa:d0",
+                    "on": true,
+                    "brightness": 80
+                  }
+                ]
+              },
+              {
+                "id": 1,
+                "name": "Evening",
+                "type": 1,
+                "modules": [
+                  {
+                    "id": "12:34:56:03:a0:ac",
+                    "target_position": 100,
+                    "fan_speed": 2
+                  }
+                ]
+              }
+            ]
           }
         ],
         "therm_setpoint_default_duration": 120,

--- a/src/pyatmo/schedule.py
+++ b/src/pyatmo/schedule.py
@@ -30,6 +30,16 @@ class Schedule(NetatmoBase):
     selected: bool
     default: bool
 
+    # electricity / electricity_production schedule fields
+    tariff: str | None
+    tariff_option: str | None
+    power_threshold: int | None
+    contract_power_unit: str | None
+
+    # event schedule twilight timetables
+    timetable_sunrise: list[TwilightEntry]
+    timetable_sunset: list[TwilightEntry]
+
     def __init__(self, home: Home, raw_data: RawData) -> None:
         """Initialize a Netatmo schedule instance."""
         super().__init__(raw_data)
@@ -40,8 +50,18 @@ class Schedule(NetatmoBase):
         self.hg_temp = raw_data.get("hg_temp")
         self.away_temp = raw_data.get("away_temp")
         self.cooling_away_temp = raw_data.get("cooling_away_temp")
+        self.tariff = raw_data.get("tariff")
+        self.tariff_option = raw_data.get("tariff_option")
+        self.power_threshold = raw_data.get("power_threshold")
+        self.contract_power_unit = raw_data.get("contract_power_unit")
         self.timetable = [
             TimetableEntry(home, r) for r in raw_data.get("timetable", [])
+        ]
+        self.timetable_sunrise = [
+            TwilightEntry(home, r) for r in raw_data.get("timetable_sunrise", [])
+        ]
+        self.timetable_sunset = [
+            TwilightEntry(home, r) for r in raw_data.get("timetable_sunset", [])
         ]
         self.zones = [Zone(home, r) for r in raw_data.get("zones", [])]
 
@@ -57,8 +77,21 @@ class Schedule(NetatmoBase):
             "cooling_away_temp",
             self.cooling_away_temp,
         )
+        self.tariff = raw_data.get("tariff", self.tariff)
+        self.tariff_option = raw_data.get("tariff_option", self.tariff_option)
+        self.power_threshold = raw_data.get("power_threshold", self.power_threshold)
+        self.contract_power_unit = raw_data.get(
+            "contract_power_unit",
+            self.contract_power_unit,
+        )
         self.timetable = [
             TimetableEntry(self.home, r) for r in raw_data.get("timetable", [])
+        ]
+        self.timetable_sunrise = [
+            TwilightEntry(self.home, r) for r in raw_data.get("timetable_sunrise", [])
+        ]
+        self.timetable_sunset = [
+            TwilightEntry(self.home, r) for r in raw_data.get("timetable_sunset", [])
         ]
 
         self.zones = [Zone(self.home, r) for r in raw_data.get("zones", [])]
@@ -79,17 +112,63 @@ class TimetableEntry:
 
 
 @dataclass
+class TwilightEntry:
+    """Class to represent an event schedule's sunrise/sunset timetable entry."""
+
+    zone_id: int | None
+    day: int | None
+    twilight_offset: int | None
+
+    def __init__(self, home: Home, raw_data: RawData) -> None:
+        """Initialize a Netatmo schedule's twilight timetable entry instance."""
+        self.home = home
+        self.zone_id = raw_data.get("zone_id", 0)
+        self.day = raw_data.get("day")
+        self.twilight_offset = raw_data.get("twilight_offset")
+
+
+@dataclass
+class ZoneModule(NetatmoBase):
+    """Class to represent an event schedule zone's per-module action."""
+
+    on: bool | None
+    target_position: int | None
+    brightness: int | None
+    fan_speed: int | None
+
+    def __init__(self, home: Home, raw_data: RawData) -> None:
+        """Initialize a Netatmo schedule zone's module action instance."""
+        super().__init__(raw_data)
+        self.home = home
+        self.bridge = raw_data.get("bridge")
+        self.on = raw_data.get("on")
+        self.target_position = raw_data.get("target_position")
+        self.brightness = raw_data.get("brightness")
+        self.fan_speed = raw_data.get("fan_speed")
+
+
+@dataclass
 class Zone(NetatmoBase):
     """Class to represent a Netatmo schedule's zone."""
 
     type: int
     rooms: list[Room]
 
+    # electricity schedule zone fields
+    price_type: str | None
+    price_value: float | None
+
+    # event schedule zone module actions
+    modules: list[ZoneModule]
+
     def __init__(self, home: Home, raw_data: RawData) -> None:
         """Initialize a Netatmo schedule's zone instance."""
         super().__init__(raw_data)
         self.home = home
         self.type = raw_data.get("type", 0)
+        self.price_type = raw_data.get("price_type")
+        self.price_value = raw_data.get("price_value")
+        self.modules = [ZoneModule(home, r) for r in raw_data.get("modules", [])]
 
         def room_factory(home: Home, room_raw_data: RawData) -> Room:
             room: Room = Room(home, room_raw_data, {})

--- a/src/pyatmo/schedule.py
+++ b/src/pyatmo/schedule.py
@@ -131,6 +131,7 @@ class TwilightEntry:
 class ZoneModule(NetatmoBase):
     """Class to represent an event schedule zone's per-module action."""
 
+    bridge: str | None
     on: bool | None
     target_position: int | None
     brightness: int | None

--- a/tests/test_home.py
+++ b/tests/test_home.py
@@ -310,6 +310,51 @@ async def test_async_account_user_country_and_consent(async_account):
     assert "user" not in async_account.raw_data
 
 
+async def test_async_home_electricity_schedule(async_home):
+    """Test electricity schedule tariff fields + zone prices are parsed."""
+    schedule = async_home.schedules["c1c54a2f45795764f59d50d9"]
+    assert schedule.type == "electricity"
+    assert schedule.tariff == "custom"
+    assert schedule.tariff_option == "peak_and_off_peak"
+    assert schedule.power_threshold == 6
+    assert schedule.contract_power_unit == "kVA"
+
+    peak = next(z for z in schedule.zones if z.entity_id == 0)
+    assert peak.price_type == "peak"
+    assert peak.price_value == 0.21
+    off_peak = next(z for z in schedule.zones if z.entity_id == 1)
+    assert off_peak.price_type == "off_peak"
+    assert off_peak.price_value == 0.16
+
+
+async def test_async_home_event_schedule(async_home):
+    """Test event schedule twilight timetables + zone module actions are parsed."""
+    schedule = async_home.schedules["d1d54a2f45795764f59d50da"]
+    assert schedule.type == "event"
+
+    assert len(schedule.timetable_sunrise) == 1
+    sunrise = schedule.timetable_sunrise[0]
+    assert sunrise.zone_id == 0
+    assert sunrise.day == 1
+    assert sunrise.twilight_offset == -30
+
+    assert len(schedule.timetable_sunset) == 1
+    assert schedule.timetable_sunset[0].twilight_offset == 15
+
+    morning = next(z for z in schedule.zones if z.entity_id == 0)
+    assert len(morning.modules) == 1
+    light = morning.modules[0]
+    assert light.entity_id == "12:34:56:00:01:ae"
+    assert light.bridge == "12:34:56:00:fa:d0"
+    assert light.on is True
+    assert light.brightness == 80
+
+    evening = next(z for z in schedule.zones if z.entity_id == 1)
+    shutter = evening.modules[0]
+    assert shutter.target_position == 100
+    assert shutter.fan_speed == 2
+
+
 def test_device_types_missing():
     """Test handling of missing device types."""
 


### PR DESCRIPTION
The single Schedule/Zone parser dropped the distinguishing payload of `electricity`/`electricity_production` and `event` schedules — they collapsed to a bare base Schedule.

- Schedule: parse `tariff`, `tariff_option`, `power_threshold`, `contract_power_unit` (electricity) and `timetable_sunrise` / `timetable_sunset` twilight timetables (event).
- Zone: parse `price_type` / `price_value` (electricity) and per-module action list `modules[]` (event).
- New dataclasses `TwilightEntry` (zone_id, day, twilight_offset) and `ZoneModule` (id, bridge, on, target_position, brightness, fan_speed).

Extend homesdata fixture with an electricity and an event schedule and assert every new field.

## Summary by Sourcery

Add support for parsing electricity and event schedule variants, including their specific tariff, pricing, twilight, and per-module action data.

New Features:
- Capture electricity schedule metadata such as tariff details, power threshold, and contract power unit on Schedule objects.
- Parse event schedule sunrise and sunset twilight timetables into dedicated TwilightEntry structures.
- Parse electricity schedule zone pricing information including price type and value.
- Parse event schedule per-module actions within zones into ZoneModule objects with control attributes.

Tests:
- Extend home async schedule tests to cover electricity and event schedules, asserting parsing of all new schedule and zone fields.