### PR TITLE
Fix homesdata module bridged key

### DIFF
--- a/src/pyatmo/modules/base_class.py
+++ b/src/pyatmo/modules/base_class.py
@@ -31,9 +31,19 @@ if TYPE_CHECKING:
 LOG: logging.Logger = logging.getLogger(__name__)
 
 
+def bridged_module_ids(raw_data: dict[str, Any], default: Any = None) -> Any:  # noqa: ANN401
+    """Return the bridged-children module ids.
+
+    The /homesdata schema documents this list as `module_bridged` in some
+    variants and `modules_bridged` in others; the API spelling is unconfirmed.
+    Both are read, and `modules_bridged` takes precedence when both are present.
+    """
+    return raw_data.get("modules_bridged", raw_data.get("module_bridged", default))
+
+
 NETATMO_ATTRIBUTES_MAP: dict[str, Callable[[dict[str, Any], Any], Any]] = {
     "entity_id": lambda x, y: x.get("id", y),
-    "modules": lambda x, y: x.get("modules_bridged", x.get("module_bridged", y)),
+    "modules": bridged_module_ids,
     "device_type": lambda x, y: DeviceType(x.get("type", y)),
     "event_type": lambda x, y: EventTypes(x.get("type", y)),
     "reachable": lambda x, _: x.get("reachable", False),

--- a/src/pyatmo/modules/base_class.py
+++ b/src/pyatmo/modules/base_class.py
@@ -33,7 +33,7 @@ LOG: logging.Logger = logging.getLogger(__name__)
 
 NETATMO_ATTRIBUTES_MAP: dict[str, Callable[[dict[str, Any], Any], Any]] = {
     "entity_id": lambda x, y: x.get("id", y),
-    "modules": lambda x, y: x.get("modules_bridged", y),
+    "modules": lambda x, y: x.get("modules_bridged", x.get("module_bridged", y)),
     "device_type": lambda x, y: DeviceType(x.get("type", y)),
     "event_type": lambda x, y: EventTypes(x.get("type", y)),
     "reachable": lambda x, _: x.get("reachable", False),

--- a/src/pyatmo/modules/module.py
+++ b/src/pyatmo/modules/module.py
@@ -1303,8 +1303,7 @@ class Module(NetatmoBase):
         self.bridge = module.get("bridge")
         # API spelling is unconfirmed: some /homesdata schemas document the
         # bridged-children list as `module_bridged`, others as `modules_bridged`.
-        # Read both so bridge/leaf logic works regardless. See
-        # homesdata-gap-fix-plan.md (Branch A).
+        # Read both so bridge/leaf logic works regardless.
         self.modules = module.get("modules_bridged", module.get("module_bridged"))
         self.device_category = DEVICE_CATEGORY_MAP.get(self.device_type)
         self.features = set()

--- a/src/pyatmo/modules/module.py
+++ b/src/pyatmo/modules/module.py
@@ -19,7 +19,13 @@ from pyatmo.const import (
     RawData,
 )
 from pyatmo.exceptions import ApiError
-from pyatmo.modules.base_class import EntityBase, NetatmoBase, Place, update_name
+from pyatmo.modules.base_class import (
+    EntityBase,
+    NetatmoBase,
+    Place,
+    bridged_module_ids,
+    update_name,
+)
 from pyatmo.modules.device_types import (
     DEVICE_CATEGORY_MAP,
     ApplianceType,
@@ -1301,10 +1307,7 @@ class Module(NetatmoBase):
         self.setup_date = module.get("setup_date")
         self.error_code = None
         self.bridge = module.get("bridge")
-        # API spelling is unconfirmed: some /homesdata schemas document the
-        # bridged-children list as `module_bridged`, others as `modules_bridged`.
-        # Read both so bridge/leaf logic works regardless.
-        self.modules = module.get("modules_bridged", module.get("module_bridged"))
+        self.modules = bridged_module_ids(module)
         self.device_category = DEVICE_CATEGORY_MAP.get(self.device_type)
         self.features = set()
 

--- a/src/pyatmo/modules/module.py
+++ b/src/pyatmo/modules/module.py
@@ -1301,7 +1301,11 @@ class Module(NetatmoBase):
         self.setup_date = module.get("setup_date")
         self.error_code = None
         self.bridge = module.get("bridge")
-        self.modules = module.get("modules_bridged")
+        # API spelling is unconfirmed: some /homesdata schemas document the
+        # bridged-children list as `module_bridged`, others as `modules_bridged`.
+        # Read both so bridge/leaf logic works regardless. See
+        # homesdata-gap-fix-plan.md (Branch A).
+        self.modules = module.get("modules_bridged", module.get("module_bridged"))
         self.device_category = DEVICE_CATEGORY_MAP.get(self.device_type)
         self.features = set()
 

--- a/tests/test_home.py
+++ b/tests/test_home.py
@@ -376,9 +376,17 @@ async def test_module_bridged_key_variants(async_home):
 
 
 async def test_module_bridged_key_topology_update(async_home):
-    """`module_bridged` fallback also works on the update_topology reflection path."""
-    mod = async_home.get_module({"id": "cc:cc", "type": "NLP"})
+    """Both bridged-key spellings work on the update_topology reflection path."""
     # update_topology -> _update_attributes drives the NETATMO_ATTRIBUTES_MAP
     # "modules" lambda, a different code path than Module.__init__.
-    mod.update_topology({"id": "cc:cc", "type": "NLP", "module_bridged": ["child-3"]})
-    assert mod.modules == ["child-3"]
+    plural = async_home.get_module({"id": "cc:cc", "type": "NLP"})
+    plural.update_topology(
+        {"id": "cc:cc", "type": "NLP", "modules_bridged": ["child-3"]},
+    )
+    assert plural.modules == ["child-3"]
+
+    singular = async_home.get_module({"id": "dd:dd", "type": "NLP"})
+    singular.update_topology(
+        {"id": "dd:dd", "type": "NLP", "module_bridged": ["child-4"]},
+    )
+    assert singular.modules == ["child-4"]

--- a/tests/test_home.py
+++ b/tests/test_home.py
@@ -360,3 +360,16 @@ def test_device_types_missing():
 
     assert DeviceType("NOC") == DeviceType.NOC
     assert DeviceType("UNKNOWN") == DeviceType.NLunknown
+
+
+async def test_module_bridged_key_variants(async_home):
+    """Both `modules_bridged` and `module_bridged` populate Module.modules."""
+    plural = async_home.get_module(
+        {"id": "aa:aa", "type": "NLP", "modules_bridged": ["child-1"]},
+    )
+    assert plural.modules == ["child-1"]
+
+    singular = async_home.get_module(
+        {"id": "bb:bb", "type": "NLP", "module_bridged": ["child-2"]},
+    )
+    assert singular.modules == ["child-2"]

--- a/tests/test_home.py
+++ b/tests/test_home.py
@@ -375,6 +375,19 @@ async def test_module_bridged_key_variants(async_home):
     assert singular.modules == ["child-2"]
 
 
+async def test_module_bridged_key_precedence(async_home):
+    """When both keys are present, `modules_bridged` wins over `module_bridged`."""
+    mod = async_home.get_module(
+        {
+            "id": "ee:ee",
+            "type": "NLP",
+            "modules_bridged": ["canonical"],
+            "module_bridged": ["alias"],
+        },
+    )
+    assert mod.modules == ["canonical"]
+
+
 async def test_module_bridged_key_topology_update(async_home):
     """Both bridged-key spellings work on the update_topology reflection path."""
     # update_topology -> _update_attributes drives the NETATMO_ATTRIBUTES_MAP

--- a/tests/test_home.py
+++ b/tests/test_home.py
@@ -391,7 +391,8 @@ async def test_module_bridged_key_precedence(async_home):
 async def test_module_bridged_key_topology_update(async_home):
     """Both bridged-key spellings work on the update_topology reflection path."""
     # update_topology -> _update_attributes drives the NETATMO_ATTRIBUTES_MAP
-    # "modules" lambda, a different code path than Module.__init__.
+    # "modules" entry (bridged_module_ids), a different code path than
+    # Module.__init__.
     plural = async_home.get_module({"id": "cc:cc", "type": "NLP"})
     plural.update_topology(
         {"id": "cc:cc", "type": "NLP", "modules_bridged": ["child-3"]},

--- a/tests/test_home.py
+++ b/tests/test_home.py
@@ -373,3 +373,12 @@ async def test_module_bridged_key_variants(async_home):
         {"id": "bb:bb", "type": "NLP", "module_bridged": ["child-2"]},
     )
     assert singular.modules == ["child-2"]
+
+
+async def test_module_bridged_key_topology_update(async_home):
+    """`module_bridged` fallback also works on the update_topology reflection path."""
+    mod = async_home.get_module({"id": "cc:cc", "type": "NLP"})
+    # update_topology -> _update_attributes drives the NETATMO_ATTRIBUTES_MAP
+    # "modules" lambda, a different code path than Module.__init__.
+    mod.update_topology({"id": "cc:cc", "type": "NLP", "module_bridged": ["child-3"]})
+    assert mod.modules == ["child-3"]


### PR DESCRIPTION
## Summary by Sourcery

Support both documented variants of the homesdata bridged module key so module child relationships are consistently populated.

Bug Fixes:
- Ensure module child relationships are populated when homesdata uses `module_bridged` instead of `modules_bridged` in both initialization and topology updates.

Tests:
- Add async tests covering both `modules_bridged` and `module_bridged` key variants and the update_topology reflection path for module bridging behavior.