### PR TITLE
Extend homesdata home geolocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and per-zone `price_type` / `price_value`) and of `event` schedules
   (`timetable_sunrise` / `timetable_sunset` twilight entries and per-zone module
   actions), previously dropped when collapsed to a base `Schedule`
+- Surface the home geolocation from the `/homesdata` topology on `Home`
+  (`altitude`, `coordinates`, `country`, `timezone`); values are exposed as-is
+  and preserved across partial topology updates
 
 ### Changed
 
@@ -49,6 +52,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   The raw `user` block is deliberately kept out of `AsyncAccount.raw_data` so
   consumers that serialize it (e.g. Home Assistant diagnostics) do not leak the
   user's email/id
+- Read the bridged-children module ids from both the `module_bridged` and
+  `modules_bridged` `/homesdata` spellings (previously only `modules_bridged`),
+  so bridged modules are no longer missed (#603)
+- Discovering a new module via `/homestatus` no longer wipes home-level fields
+  (name, therm state, geolocation) or the other known modules; the module is now
+  registered directly instead of through a partial topology update
 
 ### Removed
 

--- a/src/pyatmo/home.py
+++ b/src/pyatmo/home.py
@@ -45,6 +45,10 @@ class Home:
     auth: AbstractAsyncAuth
     entity_id: str
     name: str
+    altitude: int | None = None
+    coordinates: list[float] | None = None
+    country: str | None = None
+    timezone: str | None = None
     rooms: dict[str, Room]
     modules: dict[str, Module]
     schedules: dict[str, Schedule]
@@ -62,6 +66,10 @@ class Home:
         self.auth = auth
         self.entity_id = raw_data["id"]
         self.name = raw_data.get("name", "Unknown")
+        self.altitude = raw_data.get("altitude")
+        self.coordinates = raw_data.get("coordinates")
+        self.country = raw_data.get("country")
+        self.timezone = raw_data.get("timezone")
         self.modules = {
             module["id"]: self.get_module(module)
             for module in raw_data.get("modules", [])
@@ -111,6 +119,10 @@ class Home:
         """Update topology."""
 
         self.name = raw_data.get("name", "Unknown")
+        self.altitude = raw_data.get("altitude")
+        self.coordinates = raw_data.get("coordinates")
+        self.country = raw_data.get("country")
+        self.timezone = raw_data.get("timezone")
 
         raw_modules = raw_data.get("modules", [])
 

--- a/src/pyatmo/home.py
+++ b/src/pyatmo/home.py
@@ -45,7 +45,7 @@ class Home:
     auth: AbstractAsyncAuth
     entity_id: str
     name: str
-    altitude: float | None = None
+    altitude: int | None = None
     coordinates: list[float] | None = None
     country: str | None = None
     timezone: str | None = None
@@ -119,9 +119,10 @@ class Home:
         """Update topology."""
 
         self.name = raw_data.get("name", "Unknown")
-        # Preserve existing geolocation on partial topology updates (e.g. the
-        # `{"modules": [...]}` call in Home.update): missing keys must not wipe
-        # values already populated from a full /homesdata payload.
+        # Geolocation is treated as sticky, unlike the live state below (name,
+        # therm mode, ...): it is effectively static per home and only carried
+        # in a full /homesdata payload, so a topology update that omits these
+        # keys keeps the previously populated values instead of wiping them.
         self.altitude = raw_data.get("altitude", self.altitude)
         self.coordinates = raw_data.get("coordinates", self.coordinates)
         self.country = raw_data.get("country", self.country)

--- a/src/pyatmo/home.py
+++ b/src/pyatmo/home.py
@@ -45,7 +45,7 @@ class Home:
     auth: AbstractAsyncAuth
     entity_id: str
     name: str
-    altitude: int | None = None
+    altitude: float | None = None
     coordinates: list[float] | None = None
     country: str | None = None
     timezone: str | None = None
@@ -119,10 +119,13 @@ class Home:
         """Update topology."""
 
         self.name = raw_data.get("name", "Unknown")
-        self.altitude = raw_data.get("altitude")
-        self.coordinates = raw_data.get("coordinates")
-        self.country = raw_data.get("country")
-        self.timezone = raw_data.get("timezone")
+        # Preserve existing geolocation on partial topology updates (e.g. the
+        # `{"modules": [...]}` call in Home.update): missing keys must not wipe
+        # values already populated from a full /homesdata payload.
+        self.altitude = raw_data.get("altitude", self.altitude)
+        self.coordinates = raw_data.get("coordinates", self.coordinates)
+        self.country = raw_data.get("country", self.country)
+        self.timezone = raw_data.get("timezone", self.timezone)
 
         raw_modules = raw_data.get("modules", [])
 
@@ -198,7 +201,11 @@ class Home:
         for module in data.get("modules", []):
             has_an_update = True
             if module["id"] not in self.modules:
-                self.update_topology({"modules": [module]})
+                # Register the newly-seen module directly. Routing through
+                # update_topology with a partial `{"modules": [...]}` payload
+                # would wipe home-level fields (name, therm state, geolocation)
+                # whose keys are absent from this /homestatus data.
+                self.modules[module["id"]] = self.get_module(module)
             await self.modules[module["id"]].update(module)
             # Clear any error code from a previous /homestatus errors[] entry:
             # the module is reported healthy again. Reflection in update() would

--- a/tests/test_home.py
+++ b/tests/test_home.py
@@ -432,3 +432,47 @@ async def test_home_geolocation_topology_update(async_home):
     assert async_home.coordinates == [1.0, 2.0]
     assert async_home.country == "FR"
     assert async_home.timezone == "Europe/Paris"
+
+
+async def test_home_geolocation_partial_update_preserves(async_home):
+    """A partial topology update must not wipe known geolocation.
+
+    Home.update calls update_topology({"modules": [...]}) for newly-seen
+    modules; that payload omits the geolocation keys and must keep the
+    values already populated from /homesdata.
+    """
+    assert async_home.altitude == 112
+    assert async_home.coordinates == [52.516263, 13.377726]
+
+    async_home.update_topology({"modules": []})
+
+    assert async_home.altitude == 112
+    assert async_home.coordinates == [52.516263, 13.377726]
+    assert async_home.country == "DE"
+    assert async_home.timezone == "Europe/Berlin"
+
+
+async def test_home_update_new_module_preserves_home_fields(async_home):
+    """Discovering a new module via /homestatus must not wipe home fields.
+
+    Home.update registers a not-yet-seen module; that path must not reset
+    name/therm state/geolocation, whose keys are absent from /homestatus.
+    """
+    name = async_home.name
+    altitude = async_home.altitude
+    coordinates = async_home.coordinates
+    therm_mode = async_home.therm_mode
+    assert name == "MYHOME"
+
+    new_module = {"id": "ff:ff:ff:ff:ff:ff", "type": "NAMain"}
+    assert new_module["id"] not in async_home.modules
+
+    await async_home.update(
+        {"home": {"id": async_home.entity_id, "modules": [new_module]}},
+    )
+
+    assert new_module["id"] in async_home.modules
+    assert async_home.name == name
+    assert async_home.altitude == altitude
+    assert async_home.coordinates == coordinates
+    assert async_home.therm_mode == therm_mode

--- a/tests/test_home.py
+++ b/tests/test_home.py
@@ -404,3 +404,13 @@ async def test_module_bridged_key_topology_update(async_home):
         {"id": "dd:dd", "type": "NLP", "module_bridged": ["child-4"]},
     )
     assert singular.modules == ["child-4"]
+
+
+async def test_home_geolocation(async_home):
+    """Test home geolocation fields from /homesdata topology are surfaced."""
+    assert async_home.altitude == 112
+    assert async_home.country == "DE"
+    assert async_home.timezone == "Europe/Berlin"
+    # Coordinates are exposed as-is; the API's lat/lon ordering is ambiguous
+    # across schema variants, so the library does not reinterpret them.
+    assert async_home.coordinates == [52.516263, 13.377726]

--- a/tests/test_home.py
+++ b/tests/test_home.py
@@ -464,6 +464,11 @@ async def test_home_update_new_module_preserves_home_fields(async_home):
     therm_mode = async_home.therm_mode
     assert name == "MYHOME"
 
+    # Capture the pre-existing modules: routing a single-module payload through
+    # update_topology used to pop every other module via its removal loop.
+    existing_module_ids = set(async_home.modules)
+    assert len(existing_module_ids) > 1
+
     new_module = {"id": "ff:ff:ff:ff:ff:ff", "type": "NAMain"}
     assert new_module["id"] not in async_home.modules
 
@@ -472,6 +477,7 @@ async def test_home_update_new_module_preserves_home_fields(async_home):
     )
 
     assert new_module["id"] in async_home.modules
+    assert existing_module_ids <= set(async_home.modules)
     assert async_home.name == name
     assert async_home.altitude == altitude
     assert async_home.coordinates == coordinates

--- a/tests/test_home.py
+++ b/tests/test_home.py
@@ -414,3 +414,21 @@ async def test_home_geolocation(async_home):
     # Coordinates are exposed as-is; the API's lat/lon ordering is ambiguous
     # across schema variants, so the library does not reinterpret them.
     assert async_home.coordinates == [52.516263, 13.377726]
+
+
+async def test_home_geolocation_topology_update(async_home):
+    """Geolocation is refreshed on the update_topology path, not only __init__."""
+    async_home.update_topology(
+        {
+            "id": async_home.entity_id,
+            "name": "MYHOME",
+            "altitude": 5,
+            "coordinates": [1.0, 2.0],
+            "country": "FR",
+            "timezone": "Europe/Paris",
+        },
+    )
+    assert async_home.altitude == 5
+    assert async_home.coordinates == [1.0, 2.0]
+    assert async_home.country == "FR"
+    assert async_home.timezone == "Europe/Paris"


### PR DESCRIPTION
## Summary by Sourcery

Expose home geolocation attributes from homesdata topology and ensure they stay in sync on topology updates.

New Features:
- Add altitude, coordinates, country, and timezone attributes to the Home model populated from homesdata topology.

Tests:
- Add async tests verifying initial geolocation fields and their refresh via update_topology.