### PR TITLE
Alias legacy /homesdata module types to canonical classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Discovering a new module via `/homestatus` no longer wipes home-level fields
   (name, therm state, geolocation) or the other known modules; the module is now
   registered directly instead of through a partial topology update
+- Alias legacy/typo module type strings from `/homesdata` variants (`NBD`,
+  `NADoorTag`) to their canonical classes (`NDB`, `NACamDoorTag`) so they resolve
+  to the proper module type instead of falling back to `NLunknown`
 
 ### Removed
 

--- a/src/pyatmo/home.py
+++ b/src/pyatmo/home.py
@@ -113,8 +113,10 @@ class Home:
 
         module_type = MODULE_TYPE_ALIASES.get(module["type"], module["type"])
         if module_type != module["type"]:
+            LOG.debug("Aliased device type %s -> %s", module["type"], module_type)
             # Normalize so both the class lookup and DeviceType(...) in
-            # Module.__init__ see the canonical type.
+            # Module.__init__ see the canonical type. Copy (not mutate) to avoid
+            # rewriting the shared raw_data dict, which consumers may serialize.
             module = {**module, "type": module_type}
 
         try:

--- a/src/pyatmo/home.py
+++ b/src/pyatmo/home.py
@@ -38,6 +38,14 @@ if TYPE_CHECKING:
 
 LOG: logging.Logger = logging.getLogger(__name__)
 
+# Legacy/typo module type strings some /homesdata schema variants document,
+# mapped to the canonical type the library implements. Defensive: the live API
+# is expected to send the canonical spelling.
+MODULE_TYPE_ALIASES: dict[str, str] = {
+    "NBD": "NDB",  # transposition of Smart Video Doorbell
+    "NADoorTag": "NACamDoorTag",  # legacy Smart Door/Window Sensor name
+}
+
 
 class Home:
     """Class to represent a Netatmo home."""
@@ -103,13 +111,19 @@ class Home:
     def get_module(self, module: dict) -> Module:
         """Return module."""
 
+        module_type = MODULE_TYPE_ALIASES.get(module["type"], module["type"])
+        if module_type != module["type"]:
+            # Normalize so both the class lookup and DeviceType(...) in
+            # Module.__init__ see the canonical type.
+            module = {**module, "type": module_type}
+
         try:
-            return getattr(modules, module["type"])(
+            return getattr(modules, module_type)(
                 home=self,
                 module=module,
             )
         except AttributeError:
-            LOG.info("Unknown device type %s", module["type"])
+            LOG.info("Unknown device type %s", module_type)
             return modules.NLunknown(
                 home=self,
                 module=module,

--- a/tests/test_home.py
+++ b/tests/test_home.py
@@ -520,3 +520,16 @@ def test_account_user_units_unknown_fallback(caplog):
     assert WindUnit(99) is WindUnit.UNKNOWN
     assert PressureUnit(99) is PressureUnit.UNKNOWN
     assert "unknown" in caplog.text.lower()
+
+
+async def test_device_type_aliases(async_home):
+    """Legacy/typo module types from /homesdata resolve to canonical classes."""
+    # `NBD` is a transposition of the canonical `NDB` (Smart Video Doorbell).
+    doorbell = async_home.get_module({"id": "1", "type": "NBD"})
+    assert isinstance(doorbell, pyatmo.modules.NDB)
+    assert doorbell.device_type == DeviceType.NDB
+
+    # `NADoorTag` is a legacy alias of `NACamDoorTag`.
+    doortag = async_home.get_module({"id": "2", "type": "NADoorTag"})
+    assert isinstance(doortag, pyatmo.modules.NACamDoorTag)
+    assert doortag.device_type == DeviceType.NACamDoorTag


### PR DESCRIPTION
Some /homesdata schema variants document module types with legacy or transposed spellings (NBD for the NDB doorbell, NADoorTag for NACamDoorTag). Map them to the canonical type in Home.get_module so they resolve to the real class instead of falling back to the NLunknown stub. Defensive: the live API is expected to send the canonical spelling.

## Summary by Sourcery

Normalize legacy and typo module type identifiers in homesdata to their canonical device classes.

New Features:
- Support legacy/typo module type strings in Home.get_module by mapping them to canonical device classes.

Tests:
- Add tests verifying legacy/typo module types resolve to the correct canonical module classes and DeviceType values.