### PR TITLE
fix: give each public weather area a unique id

### DIFF
--- a/src/pyatmo/account.py
+++ b/src/pyatmo/account.py
@@ -175,9 +175,12 @@ class AsyncAccount:
         required_data_type: str | None = None,
         filtering: bool = False,
         *,
-        area_id: str = str(uuid4()),
+        area_id: str | None = None,
     ) -> str:
         """Register public weather area to monitor."""
+
+        if area_id is None:
+            area_id = str(uuid4())
 
         self.public_weather_areas[area_id] = modules.PublicWeatherArea(
             lat_ne,

--- a/tests/test_weather.py
+++ b/tests/test_weather.py
@@ -293,6 +293,30 @@ async def test_async_air_care_update(async_account):
     assert module.health_idx == 1
 
 
+async def test_register_public_weather_area_generates_unique_ids(async_account):
+    """Test that registering areas without area_id yields unique ids."""
+    lon_ne = "6.221652"
+    lat_ne = "46.610870"
+    lon_sw = "6.217828"
+    lat_sw = "46.596485"
+
+    area_id_1 = async_account.register_public_weather_area(
+        lat_ne,
+        lon_ne,
+        lat_sw,
+        lon_sw,
+    )
+    area_id_2 = async_account.register_public_weather_area(
+        lat_ne,
+        lon_ne,
+        lat_sw,
+        lon_sw,
+    )
+
+    assert area_id_1 != area_id_2
+    assert len(async_account.public_weather_areas) == 2
+
+
 async def test_async_public_weather_update(async_account):
     """Test basic public weather update."""
     lon_ne = "6.221652"


### PR DESCRIPTION
## Summary by Sourcery

Ensure public weather areas are registered with unique identifiers when no explicit area_id is provided.

Bug Fixes:
- Fix public weather area registration to avoid reusing the same default area_id across multiple areas.

Tests:
- Add a test verifying that registering multiple public weather areas without specifying area_id generates unique IDs and stores multiple areas.