### PR TITLE
fix: return 0 for unknown battery_state instead of raising

### DIFF
--- a/src/pyatmo/modules/module.py
+++ b/src/pyatmo/modules/module.py
@@ -90,7 +90,7 @@ def process_battery_state(data: str) -> int:
         "low": 25,
         "very_low": 10,
     }
-    return mapping[data]
+    return mapping.get(data, 0)
 
 
 class FirmwareMixin(EntityBase):

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -1,0 +1,28 @@
+"""Define tests for the module base helpers."""
+
+import pytest
+
+from pyatmo.modules.module import process_battery_state
+
+
+@pytest.mark.parametrize(
+    ("battery_state", "expected"),
+    [
+        ("max", 100),
+        ("full", 90),
+        ("high", 75),
+        ("medium", 50),
+        ("low", 25),
+        ("very_low", 10),
+    ],
+)
+def test_process_battery_state_known_values(battery_state: str, expected: int) -> None:
+    """Known battery states map to their percent value."""
+
+    assert process_battery_state(battery_state) == expected
+
+
+def test_process_battery_state_unknown_value_returns_zero() -> None:
+    """An unknown battery state degrades gracefully to 0 instead of raising."""
+
+    assert process_battery_state("empty") == 0


### PR DESCRIPTION
## Summary by Sourcery

Handle unknown battery_state values without raising and add tests for battery state mapping.

Bug Fixes:
- Return 0 for unknown battery_state values instead of raising a KeyError.

Tests:
- Add unit tests covering known battery_state mappings and the behavior for unknown values.