### PR TITLE
fix: make Place robust and place reflection sticky

### DIFF
--- a/src/pyatmo/modules/base_class.py
+++ b/src/pyatmo/modules/base_class.py
@@ -49,7 +49,7 @@ NETATMO_ATTRIBUTES_MAP: dict[str, Callable[[dict[str, Any], Any], Any]] = {
     "reachable": lambda x, _: x.get("reachable", False),
     "monitoring": lambda x, _: x.get("monitoring", False) == "on",
     "battery_level": lambda x, _: x.get("battery_vp", x.get("battery_level")),
-    "place": lambda x, y: Place(x["place"]) if x.get("place") is not None else y,
+    "place": lambda x, y: Place(x["place"]) if isinstance(x.get("place"), dict) else y,
     "target_position__step": lambda x, _: x.get("target_position:step"),
     "appliance_type": lambda x, y: ApplianceType(x.get("appliance_type", y)),
     "doortag_category": lambda x, y: DoorTagCategory(x.get("category", y)),
@@ -228,7 +228,7 @@ class Place:
         self.timezone = None
         self.location = None
 
-        if data is None:
+        if not isinstance(data, dict):
             LOG.debug("Place data is unknown")
             return
 
@@ -237,11 +237,13 @@ class Place:
         self.country = data.get("country")
         self.timezone = data.get("timezone")
 
-        if (location := data.get("location")) is None or len(
-            list(location),
-        ) != GPS_COORDINATES_COUNT:
+        try:
+            location_data: list[float] = list(data.get("location") or [])
+        except TypeError:
+            location_data = []
+
+        if len(location_data) != GPS_COORDINATES_COUNT:
             LOG.debug("Invalid location data: %s", data)
             return
 
-        location_data: list[float] = list(location)
         self.location = Location(location_data[0], location_data[1])

--- a/src/pyatmo/modules/base_class.py
+++ b/src/pyatmo/modules/base_class.py
@@ -49,7 +49,7 @@ NETATMO_ATTRIBUTES_MAP: dict[str, Callable[[dict[str, Any], Any], Any]] = {
     "reachable": lambda x, _: x.get("reachable", False),
     "monitoring": lambda x, _: x.get("monitoring", False) == "on",
     "battery_level": lambda x, _: x.get("battery_vp", x.get("battery_level")),
-    "place": lambda x, _: Place(x.get("place")),
+    "place": lambda x, y: Place(x["place"]) if x.get("place") is not None else y,
     "target_position__step": lambda x, _: x.get("target_position:step"),
     "appliance_type": lambda x, y: ApplianceType(x.get("appliance_type", y)),
     "doortag_category": lambda x, y: DoorTagCategory(x.get("category", y)),
@@ -222,9 +222,20 @@ class Place:
     ) -> None:
         """Initialize self."""
 
+        self.altitude = None
+        self.city = None
+        self.country = None
+        self.timezone = None
+        self.location = None
+
         if data is None:
             LOG.debug("Place data is unknown")
             return
+
+        self.altitude = data.get("altitude")
+        self.city = data.get("city")
+        self.country = data.get("country")
+        self.timezone = data.get("timezone")
 
         if (location := data.get("location")) is None or len(
             list(location),
@@ -232,9 +243,5 @@ class Place:
             LOG.debug("Invalid location data: %s", data)
             return
 
-        self.altitude = data.get("altitude")
-        self.city = data.get("city")
-        self.country = data.get("country")
-        self.timezone = data.get("timezone")
         location_data: list[float] = list(location)
         self.location = Location(location_data[0], location_data[1])

--- a/tests/test_base_class.py
+++ b/tests/test_base_class.py
@@ -37,7 +37,7 @@ def test_place_full_dict() -> None:
             "altitude": 329,
             "city": "Somewhere",
             "country": "DE",
-            "location": Location(longitude=6.1234567, latitude=46.123456),
+            "location": [6.1234567, 46.123456],
             "timezone": "Europe/Berlin",
         },
     )
@@ -47,6 +47,24 @@ def test_place_full_dict() -> None:
     assert place.country == "DE"
     assert place.timezone == "Europe/Berlin"
     assert place.location == Location(longitude=6.1234567, latitude=46.123456)
+
+
+def test_place_malformed_location_length() -> None:
+    """Wrong-length location leaves location None but keeps other fields."""
+    place = Place({"altitude": 100, "city": "X", "location": [1.0]})
+
+    assert place.altitude == 100
+    assert place.city == "X"
+    assert place.location is None
+
+
+def test_place_malformed_location_type() -> None:
+    """Non-iterable location leaves location None but keeps other fields."""
+    place = Place({"altitude": 100, "city": "X", "location": 42})
+
+    assert place.altitude == 100
+    assert place.city == "X"
+    assert place.location is None
 
 
 def test_reflection_place_absent_keeps_previous() -> None:
@@ -75,7 +93,7 @@ def test_reflection_place_present_builds_place() -> None:
                 "altitude": 329,
                 "city": "Somewhere",
                 "country": "DE",
-                "location": Location(longitude=6.1234567, latitude=46.123456),
+                "location": [6.1234567, 46.123456],
                 "timezone": "Europe/Berlin",
             },
         },
@@ -85,3 +103,25 @@ def test_reflection_place_present_builds_place() -> None:
     assert isinstance(result, Place)
     assert result.altitude == 329
     assert result.location == Location(longitude=6.1234567, latitude=46.123456)
+
+
+def test_reflection_place_present_invalid_location() -> None:
+    """Present 'place' with invalid location builds Place, location None."""
+    fn = NETATMO_ATTRIBUTES_MAP["place"]
+    sentinel = object()
+
+    result = fn(
+        {
+            "place": {
+                "altitude": 329,
+                "city": "Somewhere",
+                "location": [1.0, 2.0, 3.0],
+            },
+        },
+        sentinel,
+    )
+
+    assert isinstance(result, Place)
+    assert result.altitude == 329
+    assert result.city == "Somewhere"
+    assert result.location is None

--- a/tests/test_base_class.py
+++ b/tests/test_base_class.py
@@ -1,0 +1,87 @@
+"""Tests for pyatmo.modules.base_class Place and reflection map."""
+
+from pyatmo.modules.base_class import NETATMO_ATTRIBUTES_MAP, Location, Place
+
+
+def test_place_none_assigns_all_fields() -> None:
+    """Place(None) sets every declared field to None without raising."""
+    place = Place(None)
+
+    assert place.altitude is None
+    assert place.city is None
+    assert place.country is None
+    assert place.timezone is None
+    assert place.location is None
+
+
+def test_place_none_equality_does_not_raise() -> None:
+    """Comparing two Place(None) instances must not raise AttributeError."""
+    assert Place(None) == Place(None)
+
+
+def test_place_dict_without_location() -> None:
+    """A dict lacking a valid location keeps other fields, location is None."""
+    place = Place({"altitude": 100, "city": "X"})
+
+    assert place.altitude == 100
+    assert place.city == "X"
+    assert place.country is None
+    assert place.timezone is None
+    assert place.location is None
+
+
+def test_place_full_dict() -> None:
+    """A fully valid dict populates all fields including a Location."""
+    place = Place(
+        {
+            "altitude": 329,
+            "city": "Somewhere",
+            "country": "DE",
+            "location": Location(longitude=6.1234567, latitude=46.123456),
+            "timezone": "Europe/Berlin",
+        },
+    )
+
+    assert place.altitude == 329
+    assert place.city == "Somewhere"
+    assert place.country == "DE"
+    assert place.timezone == "Europe/Berlin"
+    assert place.location == Location(longitude=6.1234567, latitude=46.123456)
+
+
+def test_reflection_place_absent_keeps_previous() -> None:
+    """When 'place' key is absent, the previous value is kept."""
+    fn = NETATMO_ATTRIBUTES_MAP["place"]
+    sentinel = object()
+
+    assert fn({}, sentinel) is sentinel
+
+
+def test_reflection_place_null_keeps_previous() -> None:
+    """When 'place' is None, the previous value is kept."""
+    fn = NETATMO_ATTRIBUTES_MAP["place"]
+    sentinel = object()
+
+    assert fn({"place": None}, sentinel) is sentinel
+
+
+def test_reflection_place_present_builds_place() -> None:
+    """When 'place' is a valid dict, a populated Place is built."""
+    fn = NETATMO_ATTRIBUTES_MAP["place"]
+
+    result = fn(
+        {
+            "place": {
+                "altitude": 329,
+                "city": "Somewhere",
+                "country": "DE",
+                "location": Location(longitude=6.1234567, latitude=46.123456),
+                "timezone": "Europe/Berlin",
+            },
+        },
+        None,
+    )
+
+    assert isinstance(result, Place)
+    assert result.altitude == 329
+    assert result.location == Location(longitude=6.1234567, latitude=46.123456)


### PR DESCRIPTION
## Summary by Sourcery

Improve robustness of Place handling and ensure the attribute reflection map preserves existing Place values when new data lacks valid place information.

Bug Fixes:
- Avoid constructing Place from missing or null place data in NETATMO_ATTRIBUTES_MAP, preserving the previous value instead.
- Initialize Place fields to None before validation so partially populated or invalid data does not cause attribute access errors.

Tests:
- Add unit tests covering Place initialization from None and partial/complete dict data, including equality behavior.
- Add unit tests verifying that the reflection map for the place attribute keeps the previous value when place is absent or null, and builds a Place when valid data is present.