### PR TITLE
fix: fall back to NLunknown for unknown device type in update_devices

### DIFF
--- a/src/pyatmo/account.py
+++ b/src/pyatmo/account.py
@@ -290,10 +290,15 @@ class AsyncAccount:
                 )
                 device_data = normalize_weather_attributes(device_data)
                 if device_data["id"] not in self.modules:
-                    self.modules[device_data["id"]] = getattr(
+                    module_class: Any = getattr(
                         modules,
                         device_data["type"],
-                    )(
+                        None,
+                    )
+                    if module_class is None:
+                        LOG.info("Unknown device type %s", device_data["type"])
+                        module_class = modules.NLunknown
+                    self.modules[device_data["id"]] = module_class(
                         home=self,
                         module=device_data,
                     )

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -1,0 +1,23 @@
+"""Define tests for the account module."""
+
+from pyatmo import modules
+
+
+async def test_update_devices_unknown_type_falls_back_to_nlunknown(async_account):
+    """Test that an unknown standalone device type does not abort the update.
+
+    A getstationsdata/gethomecoachsdata device reporting a ``type`` with no
+    matching class in ``pyatmo.modules`` must fall back to ``NLunknown`` instead
+    of raising ``AttributeError`` and aborting the whole update.
+    """
+    device_id = "00:11:22:33:44:55"
+    device_data = {
+        "_id": device_id,
+        "type": "NOSUCHTYPE",
+    }
+
+    # Must not raise even though "NOSUCHTYPE" has no matching class.
+    await async_account.update_devices({"devices": [device_data]})
+
+    assert device_id in async_account.modules
+    assert isinstance(async_account.modules[device_id], modules.NLunknown)


### PR DESCRIPTION
Mirror Home.get_module: guard the getattr(modules, type) instantiation in AsyncAccount.update_devices with a try/except AttributeError that logs the unknown type and falls back to modules.NLunknown, so a station reporting an unmapped device type no longer aborts the whole update.

## Summary by Sourcery

Handle unknown device types in AsyncAccount.update_devices by falling back to a generic NLunknown module instead of failing the update.

Bug Fixes:
- Prevent update_devices from aborting when a station reports a device type that does not exist in pyatmo.modules.

Tests:
- Add an async account test verifying that unknown standalone device types fall back to NLunknown and do not raise during update.