### PR TITLE
Bug fix: disabled_homes_ids is not honored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Fixed
+
+- Device updates (`/getstationsdata`, `/gethomecoachsdata`) no longer re-create
+  homes excluded via `disabled_homes_ids`; the selection made through
+  `process_topology` is now remembered on the account
+  (`AsyncAccount.disabled_homes_ids`) and devices of disabled homes are skipped
+
 ## [9.5.0] - 2026-07-21
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Device updates (`/getstationsdata`, `/gethomecoachsdata`) no longer re-create
+- Device updates (`/getstationsdata`, `/gethomecoachsdata`) no longer recreate
   homes excluded via `disabled_homes_ids`; the selection made through
   `process_topology` is now remembered on the account
   (`AsyncAccount.disabled_homes_ids`) and devices of disabled homes are skipped

--- a/src/pyatmo/account.py
+++ b/src/pyatmo/account.py
@@ -49,6 +49,7 @@ class AsyncAccount:
         self.unit_wind: WindUnit | None = None
         self.unit_pressure: PressureUnit | None = None
         self.all_homes_id: dict[str, str] = {}
+        self.disabled_homes_ids: set[str] = set()
         self.homes: dict[str, Home] = {}
         self.raw_data: RawData = {}
         self.favorite_stations: bool = favorite_stations
@@ -63,19 +64,24 @@ class AsyncAccount:
         )
 
     def process_topology(self, disabled_homes_ids: list[str] | None = None) -> None:
-        """Process topology information from /homesdata."""
+        """Process topology information from /homesdata.
 
-        if disabled_homes_ids is None:
-            disabled_homes_ids = []
+        Homes listed in disabled_homes_ids are removed from the account and
+        their devices are ignored by later device updates. The selection is
+        remembered and replaced on every call; None or an empty list
+        re-enables all homes.
+        """
+
+        self.disabled_homes_ids = set(disabled_homes_ids or [])
+        for home_id in self.disabled_homes_ids & self.homes.keys():
+            del self.homes[home_id]
 
         for home in self.raw_data["homes"]:
             home_id: str = home.get("id", "Unknown")
             home_name: str = home.get("name", "Unknown")
             self.all_homes_id[home_id] = home_name
 
-            if home_id in disabled_homes_ids:
-                if home_id in self.homes:
-                    del self.homes[home_id]
+            if home_id in self.disabled_homes_ids:
                 continue
 
             if home_id in self.homes:
@@ -87,7 +93,11 @@ class AsyncAccount:
         self,
         disabled_homes_ids: list[str] | None = None,
     ) -> None:
-        """Retrieve topology data from /homesdata."""
+        """Retrieve topology data from /homesdata.
+
+        Homes listed in disabled_homes_ids are excluded from the account,
+        see process_topology.
+        """
 
         resp = await self.auth.async_post_api_request(
             endpoint=GETHOMESDATA_ENDPOINT,
@@ -247,12 +257,20 @@ class AsyncAccount:
         raw_data: RawData,
         area_id: str | None = None,
     ) -> None:
-        """Update device states."""
+        """Update device states.
+
+        Devices belonging to a disabled home are skipped, so that they do
+        not re-create the home pruned by process_topology.
+        """
         for device_data in raw_data.get("devices", {}):
-            if home_id := device_data.get(
+            home_id = device_data.get(
                 "home_id",
                 self.find_home_of_device(device_data),
-            ):
+            )
+            if home_id in self.disabled_homes_ids:
+                continue
+
+            if home_id:
                 if home_id not in self.homes:
                     modules_data: list[dict[str, Any]] = []
                     for module_data in device_data.get("modules", []):

--- a/src/pyatmo/account.py
+++ b/src/pyatmo/account.py
@@ -73,8 +73,8 @@ class AsyncAccount:
         """
 
         self.disabled_homes_ids = set(disabled_homes_ids or [])
-        for home_id in self.disabled_homes_ids & self.homes.keys():
-            del self.homes[home_id]
+        for disabled_home_id in self.disabled_homes_ids & self.homes.keys():
+            del self.homes[disabled_home_id]
 
         for home in self.raw_data["homes"]:
             home_id: str = home.get("id", "Unknown")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,6 +42,27 @@ async def async_account(async_auth):
 
 
 @pytest.fixture
+async def async_account_disabled_home(async_auth):
+    """AsyncAccount fixture with home 91763b24c43d3e344f424e8b disabled."""
+    account: pyatmo.AsyncAccount = pyatmo.AsyncAccount(async_auth)
+
+    with (
+        patch(
+            "pyatmo.auth.AbstractAsyncAuth.async_post_api_request",
+            fake_post_request,
+        ),
+        patch(
+            "pyatmo.auth.AbstractAsyncAuth.async_post_request",
+            fake_post_request,
+        ),
+    ):
+        await account.async_update_topology(
+            disabled_homes_ids=["91763b24c43d3e344f424e8b"],
+        )
+        yield account
+
+
+@pytest.fixture
 async def async_home(async_account):
     """AsyncClimate fixture for home_id 91763b24c43d3e344f424e8b."""
     home_id = "91763b24c43d3e344f424e8b"

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -1,6 +1,11 @@
 """Define tests for the account module."""
 
+from unittest.mock import patch
+
+import pyatmo
 from pyatmo import modules
+
+from .common import fake_post_request
 
 
 async def test_update_devices_unknown_type_falls_back_to_nlunknown(async_account):
@@ -21,3 +26,95 @@ async def test_update_devices_unknown_type_falls_back_to_nlunknown(async_account
 
     assert device_id in async_account.modules
     assert isinstance(async_account.modules[device_id], modules.NLunknown)
+
+
+DISABLED_HOME_ID = "91763b24c43d3e344f424e8b"
+
+
+async def test_update_devices_skips_disabled_homes(async_account_disabled_home):
+    """Test that device updates do not re-create a disabled home.
+
+    ``process_topology`` prunes disabled homes from ``homes``, but
+    ``update_devices`` used to re-create them as pseudo-homes when a weather
+    station reported the disabled ``home_id`` (getstationsdata still returns
+    every device of the account).
+    """
+    account = async_account_disabled_home
+    disabled_home_station_id = "12:34:56:80:bb:26"
+    homeless_station_id = "12:34:56:37:11:ca"
+
+    assert DISABLED_HOME_ID in account.all_homes_id
+
+    # The "MYHOME (Palier)" station reports the disabled home_id
+    await account.async_update_weather_stations()
+
+    assert DISABLED_HOME_ID not in account.homes
+    assert disabled_home_station_id not in account.modules
+    # Stations without a home are still processed account wide
+    assert homeless_station_id in account.modules
+
+    # The selection survives another topology and weather round
+    await account.async_update_topology(disabled_homes_ids=[DISABLED_HOME_ID])
+    await account.async_update_weather_stations()
+
+    assert DISABLED_HOME_ID not in account.homes
+
+
+async def test_update_devices_skips_disabled_home_coach(async_account_disabled_home):
+    """Test that a home coach reporting a disabled home is skipped.
+
+    Real ``gethomecoachsdata`` payloads usually carry no ``home_id``; such
+    devices cannot be attributed to any home and stay account scoped. This
+    covers the payloads that do report one.
+    """
+    account = async_account_disabled_home
+    home_coach_id = "00:11:22:33:44:66"
+
+    await account.update_devices(
+        {
+            "devices": [
+                {"_id": home_coach_id, "type": "NHC", "home_id": DISABLED_HOME_ID},
+            ],
+        },
+    )
+
+    assert DISABLED_HOME_ID not in account.homes
+    assert home_coach_id not in account.modules
+
+
+async def test_process_topology_prunes_unknown_disabled_home(async_auth):
+    """Test disabling prunes a pseudo-home absent from the raw topology."""
+    foreign_home_id = "aaaaaaaaaaaaaaaaaaaaaaaa"
+
+    account = pyatmo.AsyncAccount(async_auth)
+    await account.update_devices(
+        {
+            "devices": [
+                {
+                    "_id": "aa:bb:cc:dd:ee:ff",
+                    "type": "NAMain",
+                    "home_id": foreign_home_id,
+                },
+            ],
+        },
+    )
+
+    assert foreign_home_id in account.homes
+
+    with patch(
+        "pyatmo.auth.AbstractAsyncAuth.async_post_api_request",
+        fake_post_request,
+    ):
+        await account.async_update_topology(disabled_homes_ids=[foreign_home_id])
+
+    assert foreign_home_id not in account.homes
+
+
+async def test_update_topology_clears_disabled_homes(async_account_disabled_home):
+    """Test a topology refresh without disabled homes re-enables them."""
+    account = async_account_disabled_home
+
+    await account.async_update_topology()
+
+    assert not account.disabled_homes_ids
+    assert DISABLED_HOME_ID in account.homes


### PR DESCRIPTION
The device updates (`/getstationsdata`, `/gethomecoachsdata`) no longer re-create
  homes excluded via `disabled_homes_ids`; the selection made through
  `process_topology` is now remembered on the account
  (`AsyncAccount.disabled_homes_ids`) and devices of disabled homes are skipped

probably a small version bump 9.5.1 is enough here ... it is only a bug at the end

## Summary by Sourcery

Ensure disabled homes configured via topology are consistently respected during subsequent device updates.

Bug Fixes:
- Prevent weather station and home coach device updates from re-creating homes excluded via disabled_homes_ids.
- Skip devices that belong to disabled homes when updating account modules.
- Clear disabled home selections when topology is refreshed without a disabled_homes_ids list.

Enhancements:
- Persist the selection of disabled homes on AsyncAccount and reuse it across topology and device update calls.
- Improve topology processing to prune disabled homes from the account based on the stored disabled_homes_ids.

Documentation:
- Document disabled home handling behavior in process_topology, async_update_topology, and update_devices.
- Update changelog with the fix description for disabled_homes_ids handling.

Tests:
- Add async_account_disabled_home fixture to support scenarios with a pre-disabled home.
- Add tests verifying that device updates skip disabled homes for weather stations and home coaches and that topology updates can prune and re-enable homes as expected.