### PR TITLE
fix: decouple release changelog from the [unreleased] compare link

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -147,18 +147,19 @@ def finalize_changelog(
     text: str,
     version: str,
     date: str,
+    prev: str,
     repo: str = REPO_DEFAULT,
 ) -> str:
     """Return ``text`` finalized for ``version``.
 
     Renames ``## [unreleased]`` to ``## [version] - date``, inserts a fresh empty
-    ``## [unreleased]`` on top, and updates the bottom compare links.
+    ``## [unreleased]`` on top, and adds the ``vprev...vversion`` compare link.
+    ``prev`` is the previous released version (the latest git tag), which is the
+    authoritative compare base even if the changelog on this branch lags behind.
     """
     if not has_unreleased_entries(text):
         msg = "the [unreleased] section has no entries; nothing to release"
         raise ReleaseError(msg)
-
-    prev = _unreleased_prev_version(text)
 
     # Locate the unreleased section and strip its empty subsections.
     start = end = header_end = None
@@ -177,27 +178,23 @@ def finalize_changelog(
     replacement = f"## [unreleased]\n\n## [{version}] - {date}\n{cleaned}"
     new_text = text[:start] + replacement + text[end:]
 
-    # Maintain the bottom compare links.
+    # Drop any lingering ``[unreleased]`` reference link. It is intentionally not
+    # maintained -- it was a perpetual merge-conflict source between development
+    # and master. Removing it here keeps finalize idempotent on old changelogs.
+    new_text = re.sub(r"(?m)^\[unreleased\]: .*\n?", "", new_text)
+
+    # Insert the versioned compare link above the previous one.
     base = f"https://github.com/{repo}/compare"
-    return re.sub(
-        r"^\[unreleased\]: .*$",
-        f"[unreleased]: {base}/v{version}...HEAD\n"
-        f"[{version}]: {base}/v{prev}...v{version}",
+    link = f"[{version}]: {base}/v{prev}...v{version}"
+    new_text, count = re.subn(
+        r"(?m)^(\[\d+\.\d+\.\d+\]: )",
+        f"{link}\n\\1",
         new_text,
         count=1,
-        flags=re.MULTILINE,
     )
-
-
-def _unreleased_prev_version(text: str) -> str:
-    """Return the version the ``[unreleased]`` compare link currently points at."""
-    m = re.search(
-        r"^\[unreleased\]: .*/compare/v([0-9.]+)\.\.\.HEAD", text, re.MULTILINE
-    )
-    if not m:
-        msg = "could not find the [unreleased] compare link"
-        raise ReleaseError(msg)
-    return m.group(1)
+    if count == 0:  # no existing version links; append at end
+        new_text = f"{new_text.rstrip()}\n{link}\n"
+    return new_text
 
 
 def _emit_output(version: str, notes: str) -> None:
@@ -214,11 +211,12 @@ def _emit_output(version: str, notes: str) -> None:
 def _cmd_bump(args: argparse.Namespace) -> int:
     text = CHANGELOG.read_text(encoding="utf-8")
     current = _latest_tag()
+    prev = current.removeprefix("v")
     version = bump_version(current, args.bump)
     date = datetime.datetime.now(tz=datetime.UTC).strftime("%Y-%m-%d")
 
     try:
-        new_text = finalize_changelog(text, version, date)
+        new_text = finalize_changelog(text, version, date, prev)
     except ReleaseError as err:
         print(f"error: {err}", file=sys.stderr)
         return 1

--- a/tests/test_release_script.py
+++ b/tests/test_release_script.py
@@ -39,7 +39,6 @@ All notable changes to this project will be documented in this file.
 
 - Older thing
 
-[unreleased]: https://github.com/jabesq-org/pyatmo/compare/v9.4.0...HEAD
 [9.4.0]: https://github.com/jabesq-org/pyatmo/compare/v9.3.0...v9.4.0
 """
 
@@ -54,7 +53,7 @@ EMPTY_UNRELEASED = """\
 
 - Older thing
 
-[unreleased]: https://github.com/jabesq-org/pyatmo/compare/v9.4.0...HEAD
+[9.4.0]: https://github.com/jabesq-org/pyatmo/compare/v9.3.0...v9.4.0
 """
 
 
@@ -105,46 +104,75 @@ class TestUnreleasedGuard:
 
 class TestFinalizeChangelog:
     def test_renames_unreleased_with_date(self):
-        out = release.finalize_changelog(SAMPLE, "9.5.0", "2026-07-20", repo=REPO)
+        out = release.finalize_changelog(
+            SAMPLE, "9.5.0", "2026-07-20", "9.4.0", repo=REPO
+        )
         assert "## [9.5.0] - 2026-07-20" in out
 
     def test_keeps_fresh_empty_unreleased_on_top(self):
-        out = release.finalize_changelog(SAMPLE, "9.5.0", "2026-07-20", repo=REPO)
+        out = release.finalize_changelog(
+            SAMPLE, "9.5.0", "2026-07-20", "9.4.0", repo=REPO
+        )
         # unreleased header still present and appears before the new version
         assert out.index("## [unreleased]") < out.index("## [9.5.0]")
         # the released entries moved under the version, not under unreleased
         assert release.has_unreleased_entries(out) is False
 
     def test_moves_entries_under_new_version(self):
-        out = release.finalize_changelog(SAMPLE, "9.5.0", "2026-07-20", repo=REPO)
+        out = release.finalize_changelog(
+            SAMPLE, "9.5.0", "2026-07-20", "9.4.0", repo=REPO
+        )
         notes = release.extract_notes(out, "9.5.0")
         assert "A shiny new feature (#123)" in notes
         assert "A nasty bug (#124)" in notes
 
     def test_adds_compare_link_for_new_version(self):
-        out = release.finalize_changelog(SAMPLE, "9.5.0", "2026-07-20", repo=REPO)
+        out = release.finalize_changelog(
+            SAMPLE, "9.5.0", "2026-07-20", "9.4.0", repo=REPO
+        )
         assert (
             "[9.5.0]: https://github.com/jabesq-org/pyatmo/compare/v9.4.0...v9.5.0"
             in out
         )
 
-    def test_repoints_unreleased_compare_link(self):
-        out = release.finalize_changelog(SAMPLE, "9.5.0", "2026-07-20", repo=REPO)
-        assert (
-            "[unreleased]: https://github.com/jabesq-org/pyatmo/compare/v9.5.0...HEAD"
-            in out
+    def test_new_link_inserted_above_previous(self):
+        out = release.finalize_changelog(
+            SAMPLE, "9.5.0", "2026-07-20", "9.4.0", repo=REPO
         )
-        assert "compare/v9.4.0...HEAD" not in out
+        assert out.index("[9.5.0]:") < out.index("[9.4.0]:")
+
+    def test_does_not_maintain_unreleased_link(self):
+        out = release.finalize_changelog(
+            SAMPLE, "9.5.0", "2026-07-20", "9.4.0", repo=REPO
+        )
+        assert "[unreleased]: " not in out
+        assert "...HEAD" not in out
+
+    def test_removes_lingering_unreleased_link(self):
+        legacy = SAMPLE.replace(
+            "[9.4.0]: https://github.com/jabesq-org/pyatmo/compare/v9.3.0...v9.4.0",
+            "[unreleased]: https://github.com/jabesq-org/pyatmo/compare/v9.4.0...HEAD\n"
+            "[9.4.0]: https://github.com/jabesq-org/pyatmo/compare/v9.3.0...v9.4.0",
+        )
+        out = release.finalize_changelog(
+            legacy, "9.5.0", "2026-07-20", "9.4.0", repo=REPO
+        )
+        assert "[unreleased]: " not in out
+        assert "[9.5.0]:" in out
 
     def test_guard_raises_on_empty_unreleased(self):
         with pytest.raises(release.ReleaseError):
             release.finalize_changelog(
-                EMPTY_UNRELEASED, "9.5.0", "2026-07-20", repo=REPO
+                EMPTY_UNRELEASED, "9.5.0", "2026-07-20", "9.4.0", repo=REPO
             )
 
     def test_is_deterministic(self):
-        a = release.finalize_changelog(SAMPLE, "9.5.0", "2026-07-20", repo=REPO)
-        b = release.finalize_changelog(SAMPLE, "9.5.0", "2026-07-20", repo=REPO)
+        a = release.finalize_changelog(
+            SAMPLE, "9.5.0", "2026-07-20", "9.4.0", repo=REPO
+        )
+        b = release.finalize_changelog(
+            SAMPLE, "9.5.0", "2026-07-20", "9.4.0", repo=REPO
+        )
         assert a == b
 
 
@@ -169,7 +197,9 @@ class TestStripEmptySubsections:
 
 class TestFinalizeStripsEmptySections:
     def test_empty_removed_not_in_notes(self):
-        out = release.finalize_changelog(SAMPLE, "9.5.0", "2026-07-20", repo=REPO)
+        out = release.finalize_changelog(
+            SAMPLE, "9.5.0", "2026-07-20", "9.4.0", repo=REPO
+        )
         notes = release.extract_notes(out, "9.5.0")
         assert "### Removed" not in notes
         assert "### Added" in notes


### PR DESCRIPTION
The maintained [unreleased]: .../compare/vX...HEAD link was rewritten on every release, making it a recurring merge conflict between development and master during the mergeback. Stop maintaining it (and remove any lingering one), and derive the new version's compare base from the latest git tag rather than the branch's changelog, which can lag behind when a mergeback is pending.

## Summary by Sourcery

Decouple changelog finalization from the moving `[unreleased]` compare link by deriving compare bases from the latest git tag and documenting the release automation design.

Enhancements:
- Change `finalize_changelog` to accept the previous released version explicitly and derive the new version compare link from it instead of the `[unreleased]` reference link.
- Stop maintaining the `[unreleased]: ...HEAD` compare link, remove any lingering instances during finalization, and ensure new version links are inserted deterministically above existing ones.
- Update the release bump command to pass the latest tag (without `v` prefix) as the previous version into changelog finalization.

Documentation:
- Add a detailed release automation design document describing the end-to-end release workflow, branch model, changelog handling, and GitHub Actions integration.

Tests:
- Adjust release script tests to use the new `finalize_changelog` signature with an explicit previous version and add coverage for the absence and cleanup of `[unreleased]` compare links, as well as ordering of versioned links.