### PR TITLE
Add VELUX accessory and room climate parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Added
+
+- Parse VELUX ACTIVE indoor climate sensors (`NXS`), departure switches (`NXD`),
+  and room climate data.
+
 ## [9.6.0] - 2026-07-28
 
 ### Added

--- a/fixtures/homesdata_velux.json
+++ b/fixtures/homesdata_velux.json
@@ -14,7 +14,9 @@
             "reachable": true,
             "modules_bridged": [
               "velux_opener_awning",
-              "velux_opener_blind"
+              "velux_opener_blind",
+              "velux_climate_sensor",
+              "velux_departure_switch"
             ],
             "pincode_enabled": false
           },
@@ -33,6 +35,21 @@
             "bridge": "velux_gateway_id",
             "room_id": "velux_room_id",
             "velux_type": "blind"
+          },
+          {
+            "id": "velux_climate_sensor",
+            "type": "NXS",
+            "name": "Bedroom Indoor Climate Sensor",
+            "bridge": "velux_gateway_id",
+            "room_id": "velux_room_id",
+            "setup_date": 1543250432
+          },
+          {
+            "id": "velux_departure_switch",
+            "type": "NXD",
+            "name": "Departure Switch",
+            "bridge": "velux_gateway_id",
+            "setup_date": 1542892682
           }
         ],
         "rooms": [
@@ -41,7 +58,8 @@
             "name": "Bedroom",
             "module_ids": [
               "velux_opener_awning",
-              "velux_opener_blind"
+              "velux_opener_blind",
+              "velux_climate_sensor"
             ]
           }
         ],

--- a/fixtures/homestatus_velux_home_id.json
+++ b/fixtures/homestatus_velux_home_id.json
@@ -46,9 +46,52 @@
           "manufacturer": "Netatmo",
           "last_seen": 1776675797,
           "firmware_revision": 14
+        },
+        {
+          "id": "velux_climate_sensor",
+          "type": "NXS",
+          "bridge": "velux_gateway_id",
+          "reachable": true,
+          "battery_level": 3724,
+          "battery_percent": 38,
+          "battery_state": "medium",
+          "rf_state": "high",
+          "rf_strength": 64,
+          "firmware_revision": 16,
+          "last_seen": 1776675797
+        },
+        {
+          "id": "velux_departure_switch",
+          "type": "NXD",
+          "bridge": "velux_gateway_id",
+          "reachable": true,
+          "battery_level": 2332,
+          "battery_percent": 18,
+          "battery_state": "low",
+          "rf_state": "low",
+          "rf_strength": 76,
+          "firmware_revision": 16,
+          "last_seen": 1776675797
         }
       ],
-      "rooms": [],
+      "rooms": [
+        {
+          "id": "velux_room_id",
+          "air_quality": 1,
+          "algo_status": 1,
+          "algo_schedule_start": 600,
+          "auto_close_ts": 0,
+          "co2": 812,
+          "humidity": 56,
+          "lux": 6,
+          "temperature": 249,
+          "max_comfort_co2": 1150,
+          "min_comfort_humidity": 20,
+          "max_comfort_humidity": 70,
+          "min_comfort_temperature": 180,
+          "max_comfort_temperature": 230
+        }
+      ],
       "persons": [],
       "events": []
     },

--- a/src/pyatmo/modules/__init__.py
+++ b/src/pyatmo/modules/__init__.py
@@ -85,7 +85,7 @@ from .netatmo import (
 )
 from .smarther import BNS
 from .somfy import TPSRS
-from .velux import NXG, NXO
+from .velux import NXD, NXG, NXO, NXS
 
 __all__ = [
     "BNAB",
@@ -151,8 +151,10 @@ __all__ = [
     "NPC",
     "NRV",
     "NSD",
+    "NXD",
     "NXG",
     "NXO",
+    "NXS",
     "OTH",
     "OTM",
     "TPSRS",

--- a/src/pyatmo/modules/device_types.py
+++ b/src/pyatmo/modules/device_types.py
@@ -102,8 +102,10 @@ class DeviceType(StrEnum):
     NBS = "NBS"  # swing shutter
 
     # VELUX ACTIVE
+    NXD = "NXD"  # departure switch
     NXG = "NXG"  # gateway
     NXO = "NXO"  # opener / cover
+    NXS = "NXS"  # indoor climate sensor
 
     # Somfy
     TPSRS = "TPSRS"  # Somfy io shutter
@@ -168,6 +170,7 @@ DEVICE_CATEGORY_MAP: dict[DeviceType, DeviceCategory] = {
     DeviceType.NBR: DeviceCategory.shutter,
     DeviceType.NBO: DeviceCategory.shutter,
     DeviceType.NXO: DeviceCategory.shutter,
+    DeviceType.NXS: DeviceCategory.sensor,
     DeviceType.NLP: DeviceCategory.switch,
     DeviceType.NLPM: DeviceCategory.switch,
     DeviceType.NLPBS: DeviceCategory.switch,
@@ -287,8 +290,10 @@ DEVICE_DESCRIPTION_MAP: dict[DeviceType, tuple[str, str]] = {
     DeviceType.NBO: ("Bubbendorf", "Orientable Shutter"),
     DeviceType.NBS: ("Bubbendorf", "Swing Shutter"),
     # VELUX ACTIVE
+    DeviceType.NXD: ("VELUX ACTIVE", "Departure Switch"),
     DeviceType.NXG: ("VELUX ACTIVE", "Gateway"),
     DeviceType.NXO: ("VELUX ACTIVE", "Opener"),
+    DeviceType.NXS: ("VELUX ACTIVE", "Indoor Climate Sensor"),
     # Somfy
     DeviceType.TPSRS: ("Somfy", "io Shutter"),
     # 3rd Party

--- a/src/pyatmo/modules/module.py
+++ b/src/pyatmo/modules/module.py
@@ -76,6 +76,7 @@ ATTRIBUTE_FILTER = {
     "boiler_error",
     "dhw_control",
     "error_code",
+    "rf_state",
 }
 
 
@@ -119,6 +120,7 @@ class RfMixin(EntityBase):
         """Initialize rf mixin."""
 
         super().__init__(home, module)
+        self.rf_state: str | None = None
         self.rf_strength: int | None = None
 
 

--- a/src/pyatmo/modules/velux.py
+++ b/src/pyatmo/modules/velux.py
@@ -4,7 +4,15 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from pyatmo.modules.module import EntityBase, Module, Shutter, WifiMixin
+from pyatmo.modules.module import (
+    BatteryMixin,
+    EntityBase,
+    FirmwareMixin,
+    Module,
+    RfMixin,
+    Shutter,
+    WifiMixin,
+)
 
 if TYPE_CHECKING:
     from pyatmo.const import RawData
@@ -47,6 +55,10 @@ class VeluxOpenerMixin(EntityBase):
         self.velux_type: str | None = None
 
 
+class NXD(FirmwareMixin, RfMixin, BatteryMixin, Module):
+    """Class to represent a VELUX ACTIVE departure switch."""
+
+
 class NXG(VeluxGatewayMixin, WifiMixin, Module):
     """Class to represent a VELUX ACTIVE gateway."""
 
@@ -59,3 +71,7 @@ class NXG(VeluxGatewayMixin, WifiMixin, Module):
 
 class NXO(VeluxOpenerMixin, Shutter):
     """Class to represent a VELUX ACTIVE opener / cover."""
+
+
+class NXS(FirmwareMixin, RfMixin, BatteryMixin, Module):
+    """Class to represent a VELUX ACTIVE indoor climate sensor."""

--- a/src/pyatmo/room.py
+++ b/src/pyatmo/room.py
@@ -86,7 +86,19 @@ class Room(NetatmoBase):
 
     climate_type: DeviceType | None = None
 
+    air_quality: int | None = None
+    algo_schedule_start: int | None = None
+    algo_status: int | None = None
+    auto_close_ts: int | None = None
+    co2: int | None = None
     humidity: int | None = None
+    lux: int | None = None
+    max_comfort_co2: int | None = None
+    max_comfort_humidity: int | None = None
+    max_comfort_temperature: int | None = None
+    min_comfort_humidity: int | None = None
+    min_comfort_temperature: int | None = None
+    temperature: int | None = None
     therm_measured_temperature: float | None = None
 
     reachable: bool | None = None
@@ -185,7 +197,19 @@ class Room(NetatmoBase):
     def update(self, raw_data: RawData) -> None:
         """Update room data."""
 
+        self.air_quality = raw_data.get("air_quality")
+        self.algo_schedule_start = raw_data.get("algo_schedule_start")
+        self.algo_status = raw_data.get("algo_status")
+        self.auto_close_ts = raw_data.get("auto_close_ts")
+        self.co2 = raw_data.get("co2")
         self.humidity = raw_data.get("humidity")
+        self.lux = raw_data.get("lux")
+        self.max_comfort_co2 = raw_data.get("max_comfort_co2")
+        self.max_comfort_humidity = raw_data.get("max_comfort_humidity")
+        self.max_comfort_temperature = raw_data.get("max_comfort_temperature")
+        self.min_comfort_humidity = raw_data.get("min_comfort_humidity")
+        self.min_comfort_temperature = raw_data.get("min_comfort_temperature")
+        self.temperature = raw_data.get("temperature")
         self.radiators_power = 0
 
         if self.climate_type == DeviceType.BNTH:

--- a/tests/test_velux.py
+++ b/tests/test_velux.py
@@ -9,7 +9,7 @@ from pyatmo.modules.device_types import DeviceCategory
 from tests.common import MockResponse, load_fixture
 
 
-async def test_async_velux_modules(async_auth):
+async def test_async_velux_modules(async_auth, caplog):
     """Test VELUX gateway and cover parsing."""
     homesdata = json.loads(load_fixture("homesdata_velux.json"))
     homestatus = json.loads(load_fixture("homestatus_velux_home_id.json"))
@@ -40,7 +40,12 @@ async def test_async_velux_modules(async_auth):
     assert gateway.locked is True
     assert gateway.locking is False
     assert gateway.secure is True
-    assert gateway.modules == ["velux_opener_awning", "velux_opener_blind"]
+    assert gateway.modules == [
+        "velux_opener_awning",
+        "velux_opener_blind",
+        "velux_climate_sensor",
+        "velux_departure_switch",
+    ]
 
     opener = home.modules["velux_opener_awning"]
     assert opener.device_type == DeviceType.NXO
@@ -59,8 +64,104 @@ async def test_async_velux_modules(async_auth):
     blind = home.modules["velux_opener_blind"]
     assert blind.name == "Bedroom Blind"
 
+    sensor = home.modules["velux_climate_sensor"]
+    assert {
+        "device_type": sensor.device_type,
+        "device_category": sensor.device_category,
+        "name": sensor.name,
+        "bridge": sensor.bridge,
+        "room_id": sensor.room_id,
+        "setup_date": sensor.setup_date,
+        "reachable": sensor.reachable,
+        "battery_level": sensor.battery_level,
+        "battery_percent": sensor.battery_percent,
+        "battery_state": sensor.battery_state,
+        "rf_state": sensor.rf_state,
+        "rf_strength": sensor.rf_strength,
+        "firmware_revision": sensor.firmware_revision,
+        "last_seen": sensor.last_seen,
+    } == {
+        "device_type": DeviceType.NXS,
+        "device_category": DeviceCategory.sensor,
+        "name": "Bedroom Indoor Climate Sensor",
+        "bridge": "velux_gateway_id",
+        "room_id": "velux_room_id",
+        "setup_date": 1543250432,
+        "reachable": True,
+        "battery_level": 3724,
+        "battery_percent": 38,
+        "battery_state": "medium",
+        "rf_state": "high",
+        "rf_strength": 64,
+        "firmware_revision": 16,
+        "last_seen": 1776675797,
+    }
+
+    departure_switch = home.modules["velux_departure_switch"]
+    assert {
+        "device_type": departure_switch.device_type,
+        "device_category": departure_switch.device_category,
+        "name": departure_switch.name,
+        "bridge": departure_switch.bridge,
+        "room_id": departure_switch.room_id,
+        "setup_date": departure_switch.setup_date,
+        "reachable": departure_switch.reachable,
+        "battery_level": departure_switch.battery_level,
+        "battery_percent": departure_switch.battery_percent,
+        "battery_state": departure_switch.battery_state,
+        "rf_state": departure_switch.rf_state,
+        "rf_strength": departure_switch.rf_strength,
+        "firmware_revision": departure_switch.firmware_revision,
+        "last_seen": departure_switch.last_seen,
+    } == {
+        "device_type": DeviceType.NXD,
+        "device_category": None,
+        "name": "Departure Switch",
+        "bridge": "velux_gateway_id",
+        "room_id": None,
+        "setup_date": 1542892682,
+        "reachable": True,
+        "battery_level": 2332,
+        "battery_percent": 18,
+        "battery_state": "low",
+        "rf_state": "low",
+        "rf_strength": 76,
+        "firmware_revision": 16,
+        "last_seen": 1776675797,
+    }
+
     room = home.rooms["velux_room_id"]
-    assert room.device_types == {DeviceType.NXO}
+    assert room.device_types == {DeviceType.NXO, DeviceType.NXS}
+    assert {
+        "temperature": room.temperature,
+        "co2": room.co2,
+        "humidity": room.humidity,
+        "lux": room.lux,
+        "air_quality": room.air_quality,
+        "algo_status": room.algo_status,
+        "algo_schedule_start": room.algo_schedule_start,
+        "auto_close_ts": room.auto_close_ts,
+        "min_comfort_temperature": room.min_comfort_temperature,
+        "max_comfort_temperature": room.max_comfort_temperature,
+        "min_comfort_humidity": room.min_comfort_humidity,
+        "max_comfort_humidity": room.max_comfort_humidity,
+        "max_comfort_co2": room.max_comfort_co2,
+    } == {
+        "temperature": 249,
+        "co2": 812,
+        "humidity": 56,
+        "lux": 6,
+        "air_quality": 1,
+        "algo_status": 1,
+        "algo_schedule_start": 600,
+        "auto_close_ts": 0,
+        "min_comfort_temperature": 180,
+        "max_comfort_temperature": 230,
+        "min_comfort_humidity": 20,
+        "max_comfort_humidity": 70,
+        "max_comfort_co2": 1150,
+    }
+    assert "device is unknown" not in caplog.text
 
 
 async def test_async_shutter_nxo(async_auth):

--- a/tests/test_velux.py
+++ b/tests/test_velux.py
@@ -9,7 +9,7 @@ from pyatmo.modules.device_types import DeviceCategory
 from tests.common import MockResponse, load_fixture
 
 
-async def test_async_velux_modules(async_auth, caplog):
+async def test_async_velux_modules(async_auth):
     """Test VELUX gateway and cover parsing."""
     homesdata = json.loads(load_fixture("homesdata_velux.json"))
     homestatus = json.loads(load_fixture("homestatus_velux_home_id.json"))
@@ -65,6 +65,7 @@ async def test_async_velux_modules(async_auth, caplog):
     assert blind.name == "Bedroom Blind"
 
     sensor = home.modules["velux_climate_sensor"]
+    assert isinstance(sensor, pyatmo.modules.NXS)
     assert {
         "device_type": sensor.device_type,
         "device_category": sensor.device_category,
@@ -98,6 +99,7 @@ async def test_async_velux_modules(async_auth, caplog):
     }
 
     departure_switch = home.modules["velux_departure_switch"]
+    assert isinstance(departure_switch, pyatmo.modules.NXD)
     assert {
         "device_type": departure_switch.device_type,
         "device_category": departure_switch.device_category,
@@ -161,7 +163,6 @@ async def test_async_velux_modules(async_auth, caplog):
         "max_comfort_humidity": 70,
         "max_comfort_co2": 1150,
     }
-    assert "device is unknown" not in caplog.text
 
 
 async def test_async_shutter_nxo(async_auth):


### PR DESCRIPTION
## Summary

This PR adds parsing support for the remaining VELUX ACTIVE accessory and room climate data exposed by Home + Control.

It introduces support for:

- `NXS` indoor climate sensor modules
- `NXD` departure switch modules
- VELUX room climate and algorithm fields from `/homestatus`

## What changed

- Added `NXS` and `NXD` device types, module classes, descriptions, and exports
- Reused the existing battery, RF, and firmware mixins for accessory diagnostics
- Added `rf_state` to the parsed RF diagnostics
- Parsed temperature, CO2, humidity, lux, air quality, algorithm state, auto-close timestamp, and comfort thresholds on `Room`
- Added sanitized VELUX fixtures and regression coverage
- Updated the changelog

## Why

`NXS` and `NXD` currently fall back to `NLunknown`, producing warnings and dropping their typed diagnostics. Pyatmo also discards the VELUX room climate fields, which forces downstream integrations to retain and parse a parallel raw `/homestatus` payload.

The API keeps climate data on `body.home.rooms`, while battery and RF diagnostics belong to the physical `NXS` and `NXD` modules. This PR preserves that ownership and does not infer any control behavior for the departure switch.

Related downstream report: https://github.com/Niek/ha-velux-active/issues/25

## Validation

- `uv run --with ruff==0.15.12 ruff format --check --diff src/pyatmo/ tests/`
- `uv run --with ruff==0.15.12 ruff check src/pyatmo tests/`
- `uv run tox run -e 3.12,3.13,3.14,mypy`

All 198 tests pass on Python 3.12, 3.13, and 3.14, and mypy passes for all 24 source files.

## Summary by Sourcery

Add support for VELUX ACTIVE accessory types and room climate data parsing.

New Features:
- Introduce NXS indoor climate sensor and NXD departure switch device types and module classes for VELUX ACTIVE.
- Expose additional room-level climate metrics such as temperature, CO2, humidity, lux, air quality, algorithm state, and comfort thresholds.

Enhancements:
- Include RF state in RF diagnostics for applicable modules.
- Export new VELUX module types from the modules package and categorize them appropriately.

Documentation:
- Update the changelog to document new VELUX ACTIVE support.

Tests:
- Extend VELUX integration tests and fixtures to cover new accessory types, room climate parsing, and ensure unknown-device warnings are avoided.