### PR TITLE
feat: add webhook payload processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Added
+
+- Process Netatmo webhook payloads merging state changes into the local model
+
 ## [9.7.0] - 2026-08-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Process Netatmo webhook payloads merging state changes into the local model
+- Process Netatmo webhook payloads - merge state,
+  surface events, and signal refresh needs
 
 ## [9.7.0] - 2026-08-11
 

--- a/src/pyatmo/__init__.py
+++ b/src/pyatmo/__init__.py
@@ -18,7 +18,13 @@ from pyatmo.home import Home
 from pyatmo.modules import Module
 from pyatmo.modules.device_types import DeviceType
 from pyatmo.room import Room
-from pyatmo.webhook import LifecycleStatus, WebhookEvent, WebhookKind, WebhookResult
+from pyatmo.webhook import (
+    LifecycleStatus,
+    RefreshScope,
+    WebhookEvent,
+    WebhookKind,
+    WebhookResult,
+)
 from pyatmo.webrtc import WebRTCStream
 
 __all__: list[str] = [
@@ -37,6 +43,7 @@ __all__: list[str] = [
     "Module",
     "NoDeviceError",
     "NoScheduleError",
+    "RefreshScope",
     "Room",
     "WebRTCStream",
     "WebhookEvent",

--- a/src/pyatmo/__init__.py
+++ b/src/pyatmo/__init__.py
@@ -18,6 +18,7 @@ from pyatmo.home import Home
 from pyatmo.modules import Module
 from pyatmo.modules.device_types import DeviceType
 from pyatmo.room import Room
+from pyatmo.webhook import LifecycleStatus, WebhookEvent, WebhookKind, WebhookResult
 from pyatmo.webrtc import WebRTCStream
 
 __all__: list[str] = [
@@ -32,11 +33,15 @@ __all__: list[str] = [
     "InvalidHomeError",
     "InvalidRoomError",
     "InvalidScheduleError",
+    "LifecycleStatus",
     "Module",
     "NoDeviceError",
     "NoScheduleError",
     "Room",
     "WebRTCStream",
+    "WebhookEvent",
+    "WebhookKind",
+    "WebhookResult",
     "const",
     "modules",
 ]

--- a/src/pyatmo/account.py
+++ b/src/pyatmo/account.py
@@ -23,6 +23,7 @@ from pyatmo.enums import PressureUnit, UnitSystem, WindUnit
 from pyatmo.helpers import extract_raw_data
 from pyatmo.home import Home
 from pyatmo.modules.module import Energy, MeasureInterval, Module
+from pyatmo.webhook import WebhookResult, process_webhook
 
 if TYPE_CHECKING:
     from aiohttp import ClientResponse
@@ -158,6 +159,10 @@ class AsyncAccount:
         )
         raw_data: RawData = extract_raw_data(await resp.json(), HOME)
         await self.homes[home_id].update(raw_data)
+
+    async def process_webhook(self, payload: dict[str, Any]) -> WebhookResult:
+        """Parse and merge a Netatmo webhook payload into the account model."""
+        return await process_webhook(self, payload)
 
     async def async_update_weather_stations(self) -> None:
         """Retrieve status data from /getstationsdata."""

--- a/src/pyatmo/helpers.py
+++ b/src/pyatmo/helpers.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any
 
 from pyatmo.exceptions import NoDeviceError
 
@@ -13,21 +13,61 @@ if TYPE_CHECKING:
 LOG: logging.Logger = logging.getLogger(__name__)
 
 
+def str_or_none(value: Any) -> str | None:  # noqa: ANN401
+    """Return `value` if it is a string, else `None`.
+
+    Raw Netatmo scalars are not guaranteed to match their documented type.
+    Treating a wrongly-typed one as absent keeps unhashable values out of the
+    `home`/`room`/`module` id lookups, which would otherwise raise `TypeError`,
+    and keeps them off the model. Webhook payloads are the harshest case, since
+    they are caller-supplied and arrive from a public endpoint.
+    """
+    if isinstance(value, str):
+        return value
+    if value is not None:
+        LOG.debug("Discarding non-string value: %r", value)
+    return None
+
+
+def number_or_none(value: Any) -> float | None:  # noqa: ANN401
+    """Return `value` if it is a real number, else `None`.
+
+    `bool` is rejected even though it is an `int` subclass: it is never a real
+    measurement, and letting it through would store `True` as a temperature.
+    Numeric strings are rejected too rather than parsed, so a wrongly-typed
+    payload cannot overwrite a known-good reading.
+    """
+    if isinstance(value, int | float) and not isinstance(value, bool):
+        return value
+    if value is not None:
+        LOG.debug("Discarding non-numeric value: %r", value)
+    return None
+
+
+def dict_entries(value: Any) -> list[dict[str, Any]]:  # noqa: ANN401
+    """Return only the dict entries of a raw list, tolerating malformed input.
+
+    Netatmo webhook payloads are caller-supplied and arrive from a public
+    endpoint, so a list field may be absent, `null`, or hold anything at all.
+    """
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, dict)]
+
+
 def fix_id(raw_data: list[RawData | str]) -> list[RawData | str]:
     """Fix known errors in station ids like superfluous spaces."""
 
     if not raw_data:
         return raw_data
 
-    for station in raw_data:
-        if not isinstance(station, dict):
-            continue
+    for station in dict_entries(raw_data):
         if station.get("_id") is None:
             continue
 
-        station["_id"] = cast("dict", station)["_id"].replace(" ", "")
+        station["_id"] = station["_id"].replace(" ", "")
 
-        for module in station.get("modules", {}):
+        for module in station.get("modules", []):
             module["_id"] = module["_id"].replace(" ", "")
 
     return raw_data

--- a/src/pyatmo/modules/base_class.py
+++ b/src/pyatmo/modules/base_class.py
@@ -31,7 +31,10 @@ if TYPE_CHECKING:
 LOG: logging.Logger = logging.getLogger(__name__)
 
 
-def bridged_module_ids(raw_data: dict[str, Any], default: Any = None) -> Any:  # noqa: ANN401
+def bridged_module_ids(
+    raw_data: dict[str, Any],
+    default: Any = None,  # noqa: ANN401
+) -> Any:  # noqa: ANN401
     """Return the bridged-children module ids.
 
     The /homesdata schema documents this list as `module_bridged` in some

--- a/src/pyatmo/modules/module.py
+++ b/src/pyatmo/modules/module.py
@@ -1399,6 +1399,10 @@ class Module(NetatmoBase):
         """
         propagate_reachability(self, False, seen)
 
+    def mark_reachable(self, seen: set[str] | None = None) -> None:
+        """Mark this module and its children reachable, e.g. from a reconnect webhook."""
+        propagate_reachability(self, True, seen)
+
     def clear_unreachable(self, seen: set[str] | None = None) -> None:
         """Drop the mark `mark_unreachable()` left, on this module and its children.
 

--- a/src/pyatmo/webhook.py
+++ b/src/pyatmo/webhook.py
@@ -155,13 +155,13 @@ class WebhookResult:
     kind: WebhookKind
     touched_ids: list[str] = field(default_factory=list)
     events: list[WebhookEvent] = field(default_factory=list)
-    refresh_scope: RefreshScope | None = None
+    refresh_scope: frozenset[RefreshScope] = frozenset()
     lifecycle: LifecycleStatus | None = None
 
     @property
     def needs_refresh(self) -> bool:
         """True when the consumer should poll; see `refresh_scope` for which."""
-        return self.refresh_scope is not None
+        return bool(self.refresh_scope)
 
 
 def classify(event_type: str | None, push_type: str | None) -> WebhookKind:
@@ -368,9 +368,12 @@ def _process_standard_envelope(
             event_type,
             push_type,
             WebhookKind.TOPOLOGY_DIRTY,
-            refresh_scope=RefreshScope.TOPOLOGY,
+            refresh_scope=frozenset({RefreshScope.TOPOLOGY, RefreshScope.STATUS}),
         )
 
+    LOG.debug(
+        "Unrecognized webhook (event_type=%s, push_type=%s)", event_type, push_type
+    )
     return WebhookResult(home_id, event_type, push_type, WebhookKind.UNKNOWN)
 
 
@@ -383,19 +386,33 @@ async def _process_device_event(
     modules = dict_entries(extra.get("modules"))
 
     if modules:
-        touched = await _merge_device_modules(account, home_id, modules)
+        touched, unresolved = await _merge_device_modules(account, home_id, modules)
+        # A module id named in the payload but not present in the home (not
+        # merely skipped, e.g. a camera) means the consumer should re-fetch
+        # topology.
+        refresh_scope = (
+            frozenset({RefreshScope.TOPOLOGY}) if unresolved else frozenset()
+        )
         return WebhookResult(
             home_id,
             str_or_none(extra.get("event_type")),
             WEBHOOK_DEVICE_EVENT,
             WebhookKind.STATE,
             touched_ids=touched,
+            refresh_scope=refresh_scope,
         )
 
     event_type = str_or_none(extra.get("event_type"))
     if event_type:
-        touched = _merge_device_energy_event(
-            account, home_id, payload, event_type, extra
+        touched, unresolved = _merge_device_energy_event(
+            account,
+            home_id,
+            payload,
+            event_type,
+            extra,
+        )
+        refresh_scope = (
+            frozenset({RefreshScope.TOPOLOGY}) if unresolved else frozenset()
         )
         return WebhookResult(
             home_id,
@@ -403,6 +420,7 @@ async def _process_device_event(
             WEBHOOK_DEVICE_EVENT,
             WebhookKind.STATE,
             touched_ids=touched,
+            refresh_scope=refresh_scope,
         )
 
     return WebhookResult(home_id, None, WEBHOOK_DEVICE_EVENT, WebhookKind.UNKNOWN)
@@ -414,11 +432,16 @@ def _merge_device_energy_event(
     payload: dict[str, Any],
     event_type: str,
     extra: dict[str, Any],
-) -> list[str]:
+) -> tuple[list[str], bool]:
+    """Return (touched ids, whether a referenced room/module id was not found).
+
+    `boiler_event` never reports unresolved: an ambiguous skip (no bridge
+    match, more than one candidate) is expected, not a missing entity.
+    """
     if event_type == EVENT_TYPE_MOTOR_DATA_EVENT:
         return _merge_motor_data_event(account, home_id, extra)
     if event_type == EVENT_TYPE_BOILER_EVENT:
-        return _merge_boiler_event(account, home_id, payload, extra)
+        return _merge_boiler_event(account, home_id, payload, extra), False
     # setpoint_event / temperature_variation_event -- room telemetry merge.
     # Setpoints stay authoritative via display_change; never merged here.
     return _merge_device_energy_temperature(account, home_id, event_type, extra)
@@ -428,17 +451,19 @@ def _merge_motor_data_event(
     account: AsyncAccount,
     home_id: str | None,
     extra: dict[str, Any],
-) -> list[str]:
+) -> tuple[list[str], bool]:
     module_id = str_or_none(extra.get("module_id"))
     if not module_id:
-        return []
-    position = number_or_none(extra.get("current_position"))
+        return [], False
     home = account.homes.get(home_id) if home_id else None
     module = home.modules.get(module_id) if home is not None else None
-    if module is None or position is None or not hasattr(module, "current_position"):
-        return []
+    if module is None:
+        return [], True
+    position = number_or_none(extra.get("current_position"))
+    if position is None or not hasattr(module, "current_position"):
+        return [], False
     cast("ShutterMixin", module).current_position = int(position)
-    return [module_id]
+    return [module_id], False
 
 
 def _merge_boiler_event(
@@ -487,15 +512,19 @@ def _merge_device_energy_temperature(
     home_id: str | None,
     event_type: str,
     extra: dict[str, Any],
-) -> list[str]:
+) -> tuple[list[str], bool]:
     room_id = str_or_none(extra.get("room_id"))
+    if not room_id:
+        return [], False
     home = account.homes.get(home_id) if home_id else None
-    room = home.rooms.get(room_id) if home is not None and room_id else None
+    room = home.rooms.get(room_id) if home is not None else None
+    if room is None:
+        return [], True
     measured = _device_event_measured_temperature(event_type, extra)
-    if room is None or measured is None:
-        return []
+    if measured is None:
+        return [], False
     room.therm_measured_temperature = measured
-    return [room.entity_id]
+    return [room.entity_id], False
 
 
 def _normalize_device_event_module(module_data: dict[str, Any]) -> dict[str, Any]:
@@ -506,22 +535,30 @@ async def _merge_device_modules(
     account: AsyncAccount,
     home_id: str | None,
     modules: list[dict[str, Any]],
-) -> list[str]:
+) -> tuple[list[str], bool]:
+    """Return (touched ids, whether a present module id was not in the home).
+
+    A camera that is present but skipped (I/O guard) and an entry with a
+    missing/non-string id both count as resolved: `unresolved` stays False
+    for them. A malformed id is not a missing entity.
+    """
     home = account.homes.get(home_id) if home_id else None
-    if home is None:
-        return []
     touched: list[str] = []
+    unresolved = False
     for module_data in modules:
         module_id = str_or_none(module_data.get("id"))
-        module = home.modules.get(module_id) if module_id else None
+        if not module_id:
+            continue
+        module = home.modules.get(module_id) if home is not None else None
         if module is None:
+            unresolved = True
             continue
         if getattr(module, "device_category", None) == DeviceCategory.camera:
             # Camera.update() does network I/O; never run that from a webhook.
             continue
         await module.update(_normalize_device_event_module(module_data))
         touched.append(module.entity_id)
-    return touched
+    return touched, unresolved
 
 
 def _process_topology_changed(
@@ -534,7 +571,7 @@ def _process_topology_changed(
         WEBHOOK_TOPOLOGY_CHANGED,
         WebhookKind.TOPOLOGY_DIRTY,
         touched_ids=_touched_from_payload(payload),
-        refresh_scope=RefreshScope.TOPOLOGY,
+        refresh_scope=frozenset({RefreshScope.TOPOLOGY}),
     )
 
 
@@ -548,15 +585,24 @@ def _process_state(
     home = account.homes.get(home_id) if home_id else None
     if home_id is None or home is None:
         LOG.debug("Webhook STATE payload for unknown home %s; skipping", home_id)
-        return WebhookResult(home_id, event_type, push_type, WebhookKind.STATE)
+        return WebhookResult(
+            home_id,
+            event_type,
+            push_type,
+            WebhookKind.STATE,
+            refresh_scope=frozenset({RefreshScope.TOPOLOGY}),
+        )
 
     touched: list[str] = []
+    refresh_scope: frozenset[RefreshScope] = frozenset()
     if event_type in (
         EVENT_TYPE_SET_POINT,
         EVENT_TYPE_CANCEL_SET_POINT,
         EVENT_TYPE_SETPOINT_EVENT,
     ):
-        touched = _merge_rooms(home, payload)
+        touched, unresolved = _merge_rooms(home, payload)
+        if not touched and unresolved:
+            refresh_scope = frozenset({RefreshScope.TOPOLOGY})
     elif event_type == EVENT_TYPE_THERM_MODE:
         home_data = payload.get("home")
         therm_mode = (
@@ -567,10 +613,17 @@ def _process_state(
         if therm_mode is not None:
             home.therm_mode = therm_mode
             touched = [home_id]
+        # therm_mode changes every room's effective setpoint server-side; home
+        # is already known here, so this always resolves to a status poll.
+        refresh_scope = frozenset({RefreshScope.STATUS})
     elif event_type in (EVENT_TYPE_ON, EVENT_TYPE_OFF):
-        touched = _merge_camera_monitoring(home, event_type, payload)
+        touched, unresolved = _merge_camera_monitoring(home, event_type, payload)
+        if not touched and unresolved:
+            refresh_scope = frozenset({RefreshScope.TOPOLOGY})
     elif event_type == EVENT_TYPE_LIGHT_MODE:
-        touched = _merge_camera_floodlight(home, payload)
+        touched, unresolved = _merge_camera_floodlight(home, payload)
+        if not touched and unresolved:
+            refresh_scope = frozenset({RefreshScope.TOPOLOGY})
 
     return WebhookResult(
         home_id,
@@ -578,22 +631,27 @@ def _process_state(
         push_type,
         WebhookKind.STATE,
         touched_ids=touched,
+        refresh_scope=refresh_scope,
     )
 
 
-def _merge_rooms(home: Home, payload: dict[str, Any]) -> list[str]:
+def _merge_rooms(home: Home, payload: dict[str, Any]) -> tuple[list[str], bool]:
+    """Return (touched room ids, whether a referenced room id was not found)."""
     touched: list[str] = []
+    unresolved = False
     home_data = payload.get("home")
     if not isinstance(home_data, dict):
-        return touched
+        return touched, unresolved
     for room in dict_entries(home_data.get("rooms")):
         room_id = str_or_none(room.get("id"))
         room_obj = home.rooms.get(room_id) if room_id else None
         if room_obj is None:
+            if room_id:
+                unresolved = True
             continue
         if _merge_room_setpoints(room_obj, room):
             touched.append(room_obj.entity_id)
-    return touched
+    return touched, unresolved
 
 
 def _merge_room_setpoints(room_obj: Room, room: dict[str, Any]) -> bool:
@@ -619,27 +677,36 @@ def _merge_camera_monitoring(
     home: Home,
     event_type: str | None,
     payload: dict[str, Any],
-) -> list[str]:
+) -> tuple[list[str], bool]:
+    """Return (touched ids, whether a referenced camera id was not found)."""
     camera_id = _camera_id(payload)
     if not camera_id:
-        return []
+        return [], False
     module = home.modules.get(camera_id)
-    if module is None or not hasattr(module, "monitoring"):
-        return []
+    if module is None:
+        return [], True
+    if not hasattr(module, "monitoring"):
+        return [], False
     cast("MonitoringMixin", module).monitoring = event_type == EVENT_TYPE_ON
-    return [camera_id]
+    return [camera_id], False
 
 
-def _merge_camera_floodlight(home: Home, payload: dict[str, Any]) -> list[str]:
+def _merge_camera_floodlight(
+    home: Home,
+    payload: dict[str, Any],
+) -> tuple[list[str], bool]:
+    """Return (touched ids, whether a referenced camera id was not found)."""
     camera_id = _camera_id(payload)
     if not camera_id:
-        return []
+        return [], False
     module = home.modules.get(camera_id)
+    if module is None:
+        return [], True
     sub_type = str_or_none(payload.get("sub_type"))
-    if module is None or sub_type is None or not hasattr(module, "floodlight"):
-        return []
+    if sub_type is None or not hasattr(module, "floodlight"):
+        return [], False
     cast("FloodlightMixin", module).floodlight = sub_type
-    return [camera_id]
+    return [camera_id], False
 
 
 def _touched_from_payload(payload: dict[str, Any]) -> list[str]:
@@ -723,6 +790,6 @@ def _process_lifecycle(
         push_type,
         WebhookKind.LIFECYCLE,
         touched_ids=touched,
-        refresh_scope=RefreshScope.STATUS,
+        refresh_scope=frozenset({RefreshScope.STATUS}),
         lifecycle=LifecycleStatus.CONNECTION,
     )

--- a/src/pyatmo/webhook.py
+++ b/src/pyatmo/webhook.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field, replace
 from enum import Enum
 import logging
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, NamedTuple, cast
 
 from pyatmo.event import EventTypes
 from pyatmo.helpers import dict_entries, number_or_none, str_or_none
@@ -392,6 +392,24 @@ def _process_standard_envelope(
     return WebhookResult(home_id, event_type, push_type, WebhookKind.UNKNOWN)
 
 
+class MergeOutcome(NamedTuple):
+    """Result of a best-effort model merge.
+
+    `unresolved` is True only when the payload named an entity that is not
+    loaded in the home -- a missing entity worth a topology re-fetch. A
+    deliberately skipped (camera) or ambiguous (no `module_id`) target leaves
+    it False.
+    """
+
+    touched: list[str]
+    unresolved: bool
+
+
+def _topology_if_unresolved(unresolved: bool) -> frozenset[RefreshScope]:
+    """Map a missing-entity flag to a topology re-fetch, else no refresh."""
+    return frozenset({RefreshScope.TOPOLOGY}) if unresolved else frozenset()
+
+
 async def _process_device_event(
     account: AsyncAccount,
     payload: dict[str, Any],
@@ -405,9 +423,7 @@ async def _process_device_event(
         # A module id named in the payload but not present in the home (not
         # merely skipped, e.g. a camera) means the consumer should re-fetch
         # topology.
-        refresh_scope = (
-            frozenset({RefreshScope.TOPOLOGY}) if unresolved else frozenset()
-        )
+        refresh_scope = _topology_if_unresolved(unresolved)
         return WebhookResult(
             home_id,
             str_or_none(extra.get("event_type")),
@@ -427,9 +443,7 @@ async def _process_device_event(
             event_type,
             extra,
         )
-        refresh_scope = (
-            frozenset({RefreshScope.TOPOLOGY}) if unresolved else frozenset()
-        )
+        refresh_scope = _topology_if_unresolved(unresolved)
         return WebhookResult(
             home_id,
             event_type,
@@ -460,8 +474,8 @@ def _merge_device_energy_event(
     payload: dict[str, Any],
     event_type: str,
     extra: dict[str, Any],
-) -> tuple[list[str], bool]:
-    """Return (touched ids, whether a referenced room/module id was not found).
+) -> MergeOutcome:
+    """Dispatch an energy device_event to its room/module merge.
 
     `boiler_event` never reports unresolved: an ambiguous skip (no bridge
     match, more than one candidate) is expected, not a missing entity.
@@ -469,7 +483,9 @@ def _merge_device_energy_event(
     if event_type == EVENT_TYPE_MOTOR_DATA_EVENT:
         return _merge_motor_data_event(account, home_id, extra)
     if event_type == EVENT_TYPE_BOILER_EVENT:
-        return _merge_boiler_event(account, home_id, payload, extra), False
+        return MergeOutcome(
+            _merge_boiler_event(account, home_id, payload, extra), False
+        )
     if event_type == EVENT_TYPE_HEATING_POWER_REQUEST_EVENT:
         return _merge_heating_power_request_event(account, home_id, extra)
     # setpoint_event / temperature_variation_event -- room telemetry merge.
@@ -481,19 +497,19 @@ def _merge_motor_data_event(
     account: AsyncAccount,
     home_id: str | None,
     extra: dict[str, Any],
-) -> tuple[list[str], bool]:
+) -> MergeOutcome:
     module_id = str_or_none(extra.get("module_id"))
     if not module_id:
-        return [], False
+        return MergeOutcome([], False)
     home = account.homes.get(home_id) if home_id else None
     module = home.modules.get(module_id) if home is not None else None
     if module is None:
-        return [], True
+        return MergeOutcome([], True)
     position = number_or_none(extra.get("current_position"))
     if position is None or not hasattr(module, "current_position"):
-        return [], False
+        return MergeOutcome([], False)
     cast("ShutterMixin", module).current_position = int(position)
-    return [module_id], False
+    return MergeOutcome([module_id], False)
 
 
 def _merge_boiler_event(
@@ -530,19 +546,19 @@ def _merge_heating_power_request_event(
     account: AsyncAccount,
     home_id: str | None,
     extra: dict[str, Any],
-) -> tuple[list[str], bool]:
+) -> MergeOutcome:
     room_id = str_or_none(extra.get("room_id"))
     if not room_id:
-        return [], False
+        return MergeOutcome([], False)
     home = account.homes.get(home_id) if home_id else None
     room = home.rooms.get(room_id) if home is not None else None
     if room is None:
-        return [], True
+        return MergeOutcome([], True)
     request = number_or_none(extra.get("heating_power_request"))
     if request is None:
-        return [], False
+        return MergeOutcome([], False)
     room.heating_power_request = int(request)
-    return [room.entity_id], False
+    return MergeOutcome([room.entity_id], False)
 
 
 def _device_event_measured_temperature(
@@ -561,19 +577,19 @@ def _merge_device_energy_temperature(
     home_id: str | None,
     event_type: str,
     extra: dict[str, Any],
-) -> tuple[list[str], bool]:
+) -> MergeOutcome:
     room_id = str_or_none(extra.get("room_id"))
     if not room_id:
-        return [], False
+        return MergeOutcome([], False)
     home = account.homes.get(home_id) if home_id else None
     room = home.rooms.get(room_id) if home is not None else None
     if room is None:
-        return [], True
+        return MergeOutcome([], True)
     measured = _device_event_measured_temperature(event_type, extra)
     if measured is None:
-        return [], False
+        return MergeOutcome([], False)
     room.therm_measured_temperature = measured
-    return [room.entity_id], False
+    return MergeOutcome([room.entity_id], False)
 
 
 def _normalize_device_event_module(module_data: dict[str, Any]) -> dict[str, Any]:
@@ -584,8 +600,8 @@ async def _merge_device_modules(
     account: AsyncAccount,
     home_id: str | None,
     modules: list[dict[str, Any]],
-) -> tuple[list[str], bool]:
-    """Return (touched ids, whether a present module id was not in the home).
+) -> MergeOutcome:
+    """Merge each device_event module's fields into the loaded model.
 
     A camera that is present but skipped (I/O guard) and an entry with a
     missing/non-string id both count as resolved: `unresolved` stays False
@@ -607,7 +623,7 @@ async def _merge_device_modules(
             continue
         await module.update(_normalize_device_event_module(module_data))
         touched.append(module.entity_id)
-    return touched, unresolved
+    return MergeOutcome(touched, unresolved)
 
 
 def _process_topology_changed(
@@ -650,8 +666,7 @@ def _process_state(
         EVENT_TYPE_SETPOINT_EVENT,
     ):
         touched, unresolved = _merge_rooms(home, payload)
-        if not touched and unresolved:
-            refresh_scope = frozenset({RefreshScope.TOPOLOGY})
+        refresh_scope = _topology_if_unresolved(not touched and unresolved)
     elif event_type == EVENT_TYPE_THERM_MODE:
         home_data = payload.get("home")
         therm_mode = (
@@ -667,12 +682,10 @@ def _process_state(
         refresh_scope = frozenset({RefreshScope.STATUS})
     elif event_type in (EVENT_TYPE_ON, EVENT_TYPE_OFF):
         touched, unresolved = _merge_camera_monitoring(home, event_type, payload)
-        if not touched and unresolved:
-            refresh_scope = frozenset({RefreshScope.TOPOLOGY})
+        refresh_scope = _topology_if_unresolved(not touched and unresolved)
     elif event_type == EVENT_TYPE_LIGHT_MODE:
         touched, unresolved = _merge_camera_floodlight(home, payload)
-        if not touched and unresolved:
-            refresh_scope = frozenset({RefreshScope.TOPOLOGY})
+        refresh_scope = _topology_if_unresolved(not touched and unresolved)
 
     return WebhookResult(
         home_id,
@@ -684,13 +697,13 @@ def _process_state(
     )
 
 
-def _merge_rooms(home: Home, payload: dict[str, Any]) -> tuple[list[str], bool]:
-    """Return (touched room ids, whether a referenced room id was not found)."""
+def _merge_rooms(home: Home, payload: dict[str, Any]) -> MergeOutcome:
+    """Merge setpoint keys for each room named in the payload."""
     touched: list[str] = []
     unresolved = False
     home_data = payload.get("home")
     if not isinstance(home_data, dict):
-        return touched, unresolved
+        return MergeOutcome(touched, unresolved)
     for room in dict_entries(home_data.get("rooms")):
         room_id = str_or_none(room.get("id"))
         room_obj = home.rooms.get(room_id) if room_id else None
@@ -700,7 +713,7 @@ def _merge_rooms(home: Home, payload: dict[str, Any]) -> tuple[list[str], bool]:
             continue
         if _merge_room_setpoints(room_obj, room):
             touched.append(room_obj.entity_id)
-    return touched, unresolved
+    return MergeOutcome(touched, unresolved)
 
 
 def _merge_room_setpoints(room_obj: Room, room: dict[str, Any]) -> bool:
@@ -726,36 +739,36 @@ def _merge_camera_monitoring(
     home: Home,
     event_type: str | None,
     payload: dict[str, Any],
-) -> tuple[list[str], bool]:
-    """Return (touched ids, whether a referenced camera id was not found)."""
+) -> MergeOutcome:
+    """Merge camera monitoring on/off state."""
     camera_id = _camera_id(payload)
     if not camera_id:
-        return [], False
+        return MergeOutcome([], False)
     module = home.modules.get(camera_id)
     if module is None:
-        return [], True
+        return MergeOutcome([], True)
     if not hasattr(module, "monitoring"):
-        return [], False
+        return MergeOutcome([], False)
     cast("MonitoringMixin", module).monitoring = event_type == EVENT_TYPE_ON
-    return [camera_id], False
+    return MergeOutcome([camera_id], False)
 
 
 def _merge_camera_floodlight(
     home: Home,
     payload: dict[str, Any],
-) -> tuple[list[str], bool]:
-    """Return (touched ids, whether a referenced camera id was not found)."""
+) -> MergeOutcome:
+    """Merge camera floodlight (light_mode) state."""
     camera_id = _camera_id(payload)
     if not camera_id:
-        return [], False
+        return MergeOutcome([], False)
     module = home.modules.get(camera_id)
     if module is None:
-        return [], True
+        return MergeOutcome([], True)
     sub_type = str_or_none(payload.get("sub_type"))
     if sub_type is None or not hasattr(module, "floodlight"):
-        return [], False
+        return MergeOutcome([], False)
     cast("FloodlightMixin", module).floodlight = sub_type
-    return [camera_id], False
+    return MergeOutcome([camera_id], False)
 
 
 def _touched_from_payload(payload: dict[str, Any]) -> list[str]:
@@ -817,7 +830,7 @@ def _process_lifecycle(
     home = account.homes.get(home_id) if home_id else None
     camera_id = _camera_id(payload)
     module = home.modules.get(camera_id) if home is not None and camera_id else None
-    touched = [camera_id] if module is not None else []
+    touched = [camera_id] if camera_id and module is not None else []
 
     if _is_disconnection(event_type, push_type):
         if module is not None:

--- a/src/pyatmo/webhook.py
+++ b/src/pyatmo/webhook.py
@@ -37,6 +37,7 @@ EVENT_TYPE_SCHEDULE = "schedule"
 EVENT_TYPE_TEMPERATURE_VARIATION_EVENT = "temperature_variation_event"
 EVENT_TYPE_MOTOR_DATA_EVENT = "motor_data_event"
 EVENT_TYPE_BOILER_EVENT = "boiler_event"
+EVENT_TYPE_HEATING_POWER_REQUEST_EVENT = "heating_power_request_event"
 
 # device_event energy `event_type`s with a known merge; anything else with a
 # resolved type (e.g. diagnosis_event) is surfaced as an EVENT, unmerged.
@@ -46,6 +47,7 @@ _DEVICE_ENERGY_EVENT_TYPES = frozenset(
         EVENT_TYPE_SETPOINT_EVENT,
         EVENT_TYPE_MOTOR_DATA_EVENT,
         EVENT_TYPE_BOILER_EVENT,
+        EVENT_TYPE_HEATING_POWER_REQUEST_EVENT,
     },
 )
 
@@ -468,6 +470,8 @@ def _merge_device_energy_event(
         return _merge_motor_data_event(account, home_id, extra)
     if event_type == EVENT_TYPE_BOILER_EVENT:
         return _merge_boiler_event(account, home_id, payload, extra), False
+    if event_type == EVENT_TYPE_HEATING_POWER_REQUEST_EVENT:
+        return _merge_heating_power_request_event(account, home_id, extra)
     # setpoint_event / temperature_variation_event -- room telemetry merge.
     # Setpoints stay authoritative via display_change; never merged here.
     return _merge_device_energy_temperature(account, home_id, event_type, extra)
@@ -520,6 +524,25 @@ def _merge_boiler_event(
 
     cast("BoilerMixin", target).boiler_status = mapped
     return [target.entity_id]
+
+
+def _merge_heating_power_request_event(
+    account: AsyncAccount,
+    home_id: str | None,
+    extra: dict[str, Any],
+) -> tuple[list[str], bool]:
+    room_id = str_or_none(extra.get("room_id"))
+    if not room_id:
+        return [], False
+    home = account.homes.get(home_id) if home_id else None
+    room = home.rooms.get(room_id) if home is not None else None
+    if room is None:
+        return [], True
+    request = number_or_none(extra.get("heating_power_request"))
+    if request is None:
+        return [], False
+    room.heating_power_request = int(request)
+    return [room.entity_id], False
 
 
 def _device_event_measured_temperature(

--- a/src/pyatmo/webhook.py
+++ b/src/pyatmo/webhook.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from enum import Enum
 import logging
 from typing import TYPE_CHECKING, Any, cast
@@ -26,19 +26,14 @@ EVENT_TYPE_OFF = "off"
 EVENT_TYPE_LIGHT_MODE = "light_mode"
 EVENT_TYPE_SET_POINT = "set_point"
 EVENT_TYPE_CANCEL_SET_POINT = "cancel_set_point"
-# Real `display_change` payloads use this name instead of `set_point`; same
-# nested `home.rooms[]` therm_setpoint_* keys, so it is treated as an alias.
 EVENT_TYPE_SETPOINT_EVENT = "setpoint_event"
 EVENT_TYPE_THERM_MODE = "therm_mode"
 EVENT_TYPE_SCHEDULE = "schedule"
+EVENT_TYPE_TEMPERATURE_VARIATION_EVENT = "temperature_variation_event"
 
 WEBHOOK_ACTIVATION = "webhook_activation"
 WEBHOOK_DEACTIVATION = "webhook_deactivation"
-# A second envelope format: no top-level event_type, real content nested in
-# `extra_params`. Routed by `_process_device_event`, before `classify()`.
 WEBHOOK_DEVICE_EVENT = "device_event"
-# Structural change (module added / moved to a room / firmware or device
-# update). No top-level event_type; a `change` field names the variant.
 WEBHOOK_TOPOLOGY_CHANGED = "topology_changed"
 CAMERA_CONNECTION_WEBHOOKS = frozenset(
     {"NACamera-connection", "NOC-connection", "NDB-connection"},
@@ -101,12 +96,7 @@ class LifecycleStatus(Enum):
 
 
 class RefreshScope(Enum):
-    """Which poll a consumer should run to reconcile after a webhook.
-
-    TOPOLOGY -> async_update_topology (/homesdata): structural or schedule
-    changes. STATUS -> async_update_status (/homestatus): live device state,
-    e.g. after a camera reconnect.
-    """
+    """Which poll a consumer should run to reconcile after a webhook."""
 
     TOPOLOGY = "topology"
     STATUS = "status"
@@ -114,12 +104,7 @@ class RefreshScope(Enum):
 
 @dataclass(frozen=True)
 class WebhookEvent:
-    """A parsed webhook event (distinct from the /getevents Event stream).
-
-    `frozen` prevents rebinding an attribute but not mutating one: `person_ids`
-    and `raw` stay mutable, so instances are not hashable and `hash()` or set
-    membership raises `TypeError`. Compare them by value instead.
-    """
+    """A parsed webhook event (distinct from the /getevents Event stream)."""
 
     event_type: str | None
     push_type: str | None
@@ -127,24 +112,23 @@ class WebhookEvent:
     module_id: str | None = None
     camera_id: str | None = None
     device_id: str | None = None
-    person_ids: list[str] = field(default_factory=list)
+    room_id: str | None = None
+    mode: str | None = None
+    person_id: str | None = None
+    person_name: str | None = None
+    is_known: bool | None = None
+    face_url: str | None = None
     sub_type: str | None = None
     snapshot_url: str | None = None
+    vignette_url: str | None = None
+    event_id: str | None = None
     message: str | None = None
     raw: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)
 class WebhookResult:
-    """Outcome of processing one webhook payload.
-
-    Not hashable, for the same reason as `WebhookEvent`: `touched_ids` and
-    `events` stay mutable despite `frozen`. Compare by value instead.
-
-    The `touched_ids` namespace depends on `event_type` -- room ids for
-    set_point and cancel_set_point, the home id for therm_mode, module ids for
-    on/off, light_mode and EVENT payloads.
-    """
+    """Outcome of processing one webhook payload."""
 
     home_id: str | None
     event_type: str | None
@@ -184,62 +168,124 @@ def resolve_home_id(payload: dict[str, Any]) -> str | None:
 
 
 def _extra_params(payload: dict[str, Any]) -> dict[str, Any]:
-    """Return the `device_event` envelope's `extra_params` block, or `{}`.
-
-    That envelope nests its real content here instead of at the top level;
-    callers must tolerate a missing or malformed block without raising.
-    """
     extra = payload.get("extra_params")
     return extra if isinstance(extra, dict) else {}
 
 
-def build_webhook_event(payload: dict[str, Any]) -> WebhookEvent:
-    """Build a WebhookEvent from an EVENT-class payload.
+def _bool_or_none(value: Any) -> bool | None:  # noqa: ANN401
+    return value if isinstance(value, bool) else None
 
-    `event_type` falls back to `extra_params.event_type` for the
-    `device_event` envelope, which carries no top-level `event_type`.
-    """
+
+def _resolve_person_name(home: Home | None, person_id: str | None) -> str | None:
+    if home is None or person_id is None:
+        return None
+    person = home.persons.get(person_id)
+    return getattr(person, "pseudo", None)
+
+
+def _shared_event_fields(
+    payload: dict[str, Any],
+    extra: dict[str, Any],
+    home_id: str | None,
+    push_type: str | None,
+    event_type: str | None,
+) -> dict[str, Any]:
+    return {
+        "event_type": event_type,
+        "push_type": push_type,
+        "home_id": home_id,
+        "module_id": str_or_none(payload.get("module_id")),
+        "camera_id": str_or_none(payload.get("camera_id")),
+        "device_id": str_or_none(payload.get("device_id")),
+        "room_id": str_or_none(payload.get("room_id"))
+        or str_or_none(extra.get("room_id")),
+        "mode": str_or_none(payload.get("mode")) or str_or_none(extra.get("mode")),
+        "sub_type": str_or_none(payload.get("sub_type")),
+        "snapshot_url": str_or_none(payload.get("snapshot_url")),
+        "vignette_url": str_or_none(payload.get("vignette_url")),
+        "event_id": str_or_none(payload.get("event_id")),
+        "message": str_or_none(payload.get("message")),
+        "raw": payload,
+    }
+
+
+def _build_person_event(
+    payload: dict[str, Any],
+    extra: dict[str, Any],
+    person: dict[str, Any],
+    *,
+    home: Home | None,
+    home_id: str | None,
+    push_type: str | None,
+) -> WebhookEvent:
+    person_id = str_or_none(person.get("id"))
     return WebhookEvent(
-        event_type=str_or_none(payload.get("event_type"))
-        or str_or_none(_extra_params(payload).get("event_type")),
-        push_type=str_or_none(payload.get("push_type")),
-        home_id=resolve_home_id(payload),
-        module_id=str_or_none(payload.get("module_id")),
-        camera_id=str_or_none(payload.get("camera_id")),
-        device_id=str_or_none(payload.get("device_id")),
-        person_ids=[
-            person_id
-            for person in dict_entries(payload.get("persons"))
-            if (person_id := str_or_none(person.get("id")))
-        ],
-        sub_type=str_or_none(payload.get("sub_type")),
-        snapshot_url=str_or_none(payload.get("snapshot_url")),
-        message=str_or_none(payload.get("message")),
-        raw=payload,
+        **_shared_event_fields(payload, extra, home_id, push_type, "person"),
+        person_id=person_id,
+        is_known=_bool_or_none(person.get("is_known")),
+        face_url=str_or_none(person.get("face_url")),
+        person_name=_resolve_person_name(home, person_id),
     )
+
+
+def build_webhook_events(
+    payload: dict[str, Any],
+    home: Home | None,
+) -> list[WebhookEvent]:
+    """Build the WebhookEvent(s) a payload carries, regardless of `kind`."""
+    extra = _extra_params(payload)
+    home_id = resolve_home_id(payload)
+    push_type = str_or_none(payload.get("push_type"))
+
+    modules = dict_entries(extra.get("modules"))
+    if modules:
+        device_id = str_or_none(payload.get("device_id"))
+        return [
+            WebhookEvent(
+                event_type=None,
+                push_type=push_type,
+                home_id=home_id,
+                module_id=str_or_none(module.get("id")),
+                room_id=str_or_none(module.get("room_id")),
+                device_id=device_id,
+                raw=payload,
+            )
+            for module in modules
+        ]
+
+    event_type = str_or_none(payload.get("event_type")) or str_or_none(
+        extra.get("event_type"),
+    )
+    if event_type is None:
+        return []
+
+    if event_type == "person":
+        persons = dict_entries(payload.get("persons"))
+        if persons:
+            return [
+                _build_person_event(
+                    payload,
+                    extra,
+                    person,
+                    home=home,
+                    home_id=home_id,
+                    push_type=push_type,
+                )
+                for person in persons
+            ]
+
+    return [
+        WebhookEvent(
+            **_shared_event_fields(payload, extra, home_id, push_type, event_type),
+        ),
+    ]
 
 
 async def process_webhook(
     account: AsyncAccount,
     payload: dict[str, Any],
 ) -> WebhookResult:
-    """Parse, normalize, and merge a Netatmo webhook payload.
-
-    Performs no I/O and never suspends for the standard envelope, because
-    Netatmo requires a webhook endpoint to answer immediately and deactivates
-    one that does not. Do not add an `await` here: it would put network
-    latency, including the 429 backoff in `auth.py`, on the response path. The
-    `device_event` envelope is the one documented exception: its module merge
-    goes through `Module.update`, which is `async` but performs no I/O of its
-    own for the plain (non-Camera) modules it is used for today.
-
-    Merging is therefore best-effort. An `async_update_*` call already in flight
-    fetched its snapshot before this payload arrived, and will overwrite the
-    merge when it completes; the next successful poll restores the true state,
-    since the server is authoritative. Callers that need the merge to survive
-    should answer the webhook first and then apply the result in a task ordered
-    after any in-flight refresh -- `needs_refresh` schedules that follow-up.
-    """
+    """Parse, normalize, and merge a Netatmo webhook payload."""
     event_type = str_or_none(payload.get("event_type"))
     push_type = str_or_none(payload.get("push_type"))
     home_id = resolve_home_id(payload)
@@ -248,13 +294,22 @@ async def process_webhook(
         LOG.debug("Webhook payload without event_type/push_type: %s", payload)
         return WebhookResult(home_id, event_type, push_type, WebhookKind.UNKNOWN)
 
+    # No await here except device_event's module merge -- never suspend on the webhook response path.
     if push_type == WEBHOOK_DEVICE_EVENT:
-        return await _process_device_event(account, payload)
+        result = await _process_device_event(account, payload)
+    elif push_type == WEBHOOK_TOPOLOGY_CHANGED:
+        result = _process_topology_changed(home_id, payload)
+    else:
+        result = _process_standard_envelope(
+            account,
+            home_id,
+            event_type,
+            push_type,
+            payload,
+        )
 
-    if push_type == WEBHOOK_TOPOLOGY_CHANGED:
-        return _process_topology_changed(home_id, payload)
-
-    return _process_standard_envelope(account, home_id, event_type, push_type, payload)
+    home = account.homes.get(home_id) if home_id else None
+    return replace(result, events=build_webhook_events(payload, home))
 
 
 def _process_standard_envelope(
@@ -264,12 +319,6 @@ def _process_standard_envelope(
     push_type: str | None,
     payload: dict[str, Any],
 ) -> WebhookResult:
-    """Route the standard top-level-`event_type` envelope via `classify()`.
-
-    Split out of `process_webhook` so `device_event` -- which carries no
-    top-level `event_type` and is routed before `classify()` runs -- cannot
-    reach here, keeping `classify()` pure for this envelope shape.
-    """
     kind = classify(event_type, push_type)
 
     if kind is WebhookKind.LIFECYCLE:
@@ -297,20 +346,6 @@ async def _process_device_event(
     account: AsyncAccount,
     payload: dict[str, Any],
 ) -> WebhookResult:
-    """Route a `device_event` envelope by its `extra_params` contents.
-
-    - `extra_params.modules[]` present -> STATE, merged via `Module.update`
-      (reflection-based, so it keeps attributes absent from the partial
-      payload, unlike `Room.update`).
-    - else `extra_params.event_type` present (energy events such as
-      `setpoint_event`/`temperature_variation_event`) -> EVENT, surfaced only;
-      no state merge. These use a different key schema (`temperature`/
-      `setpoint`/`ts_begin`/`ts_end`, not `therm_setpoint_*`) than the
-      top-level `display_change` payload Netatmo also sends for the same
-      change, which is the authoritative, cleanly-keyed source for the room
-      merge -- merging both would double-apply.
-    - else -> UNKNOWN, no mutation.
-    """
     extra = _extra_params(payload)
     home_id = resolve_home_id(payload)
     modules = dict_entries(extra.get("modules"))
@@ -327,17 +362,44 @@ async def _process_device_event(
 
     event_type = str_or_none(extra.get("event_type"))
     if event_type:
-        device_id = str_or_none(payload.get("device_id"))
+        # Merge measured temperature only; setpoints stay authoritative via display_change.
+        touched = _merge_device_energy_temperature(account, home_id, event_type, extra)
         return WebhookResult(
             home_id,
             event_type,
             WEBHOOK_DEVICE_EVENT,
-            WebhookKind.EVENT,
-            touched_ids=[device_id] if device_id else [],
-            events=[build_webhook_event(payload)],
+            WebhookKind.STATE,
+            touched_ids=touched,
         )
 
     return WebhookResult(home_id, None, WEBHOOK_DEVICE_EVENT, WebhookKind.UNKNOWN)
+
+
+def _device_event_measured_temperature(
+    event_type: str,
+    extra: dict[str, Any],
+) -> float | None:
+    if event_type == EVENT_TYPE_TEMPERATURE_VARIATION_EVENT:
+        return number_or_none(extra.get("temperature"))
+    if event_type == EVENT_TYPE_SETPOINT_EVENT:
+        return number_or_none(extra.get("therm_measured_temperature"))
+    return None
+
+
+def _merge_device_energy_temperature(
+    account: AsyncAccount,
+    home_id: str | None,
+    event_type: str,
+    extra: dict[str, Any],
+) -> list[str]:
+    room_id = str_or_none(extra.get("room_id"))
+    home = account.homes.get(home_id) if home_id else None
+    room = home.rooms.get(room_id) if home is not None and room_id else None
+    measured = _device_event_measured_temperature(event_type, extra)
+    if room is None or measured is None:
+        return []
+    room.therm_measured_temperature = measured
+    return [room.entity_id]
 
 
 async def _merge_device_modules(
@@ -345,15 +407,6 @@ async def _merge_device_modules(
     home_id: str | None,
     modules: list[dict[str, Any]],
 ) -> list[str]:
-    """Merge each module via `Module.update`, a safe partial merge.
-
-    Unlike `Room.update`, `Module.update` is reflection-based and preserves
-    attributes absent from the partial payload. Camera-category modules are
-    skipped: `Camera.update` calls `async_update_camera_urls`, which performs
-    network I/O and must never run on the webhook response path. Current
-    `device_event` payloads only carry dimmers/switches, but this guards
-    defensively against a future payload naming a camera.
-    """
     home = account.homes.get(home_id) if home_id else None
     if home is None:
         return []
@@ -364,6 +417,7 @@ async def _merge_device_modules(
         if module is None:
             continue
         if getattr(module, "device_category", None) == DeviceCategory.camera:
+            # Camera.update() does network I/O; never run that from a webhook.
             continue
         await module.update(module_data)
         touched.append(module.entity_id)
@@ -374,13 +428,6 @@ def _process_topology_changed(
     home_id: str | None,
     payload: dict[str, Any],
 ) -> WebhookResult:
-    """Route a `topology_changed` envelope to TOPOLOGY_DIRTY.
-
-    The payload carries a partial `home.modules[]`, but it is not merged: a
-    full `async_update_topology` refresh (signalled by `needs_refresh`) is the
-    authoritative way to pick up structural changes. `event_type` carries the
-    `change` variant; `touched_ids` the module/device ids referenced.
-    """
     return WebhookResult(
         home_id,
         str_or_none(payload.get("change")),
@@ -435,7 +482,6 @@ def _process_state(
 
 
 def _merge_rooms(home: Home, payload: dict[str, Any]) -> list[str]:
-    """Merge only the setpoint fields present in the payload into each room."""
     touched: list[str] = []
     home_data = payload.get("home")
     if not isinstance(home_data, dict):
@@ -451,12 +497,6 @@ def _merge_rooms(home: Home, payload: dict[str, Any]) -> list[str]:
 
 
 def _merge_room_setpoints(room_obj: Room, room: dict[str, Any]) -> bool:
-    """Apply the payload's setpoint fields to `room_obj`; return True if any stuck.
-
-    An explicit `null` is honoured and clears the field, since that is how a
-    cancelled setpoint arrives. A value of the wrong type is dropped instead,
-    so a malformed payload cannot overwrite a known-good reading.
-    """
     applied = False
     for key, coerce in _ROOM_SETPOINT_KEYS.items():
         if key not in room:
@@ -503,7 +543,6 @@ def _merge_camera_floodlight(home: Home, payload: dict[str, Any]) -> list[str]:
 
 
 def _touched_from_payload(payload: dict[str, Any]) -> list[str]:
-    """De-duplicated device/camera/module ids referenced by the payload."""
     ids: list[str] = []
     for key in ("device_id", "camera_id", "module_id"):
         value = str_or_none(payload.get(key))
@@ -524,7 +563,6 @@ def _process_event(
         push_type,
         WebhookKind.EVENT,
         touched_ids=_touched_from_payload(payload),
-        events=[build_webhook_event(payload)],
     )
 
 
@@ -539,7 +577,7 @@ def _process_lifecycle(
     elif push_type == WEBHOOK_DEACTIVATION:
         lifecycle = LifecycleStatus.DEACTIVATION
         refresh_scope = None
-    else:  # camera reconnect
+    else:
         lifecycle = LifecycleStatus.CONNECTION
         refresh_scope = RefreshScope.STATUS
     return WebhookResult(

--- a/src/pyatmo/webhook.py
+++ b/src/pyatmo/webhook.py
@@ -37,6 +37,9 @@ WEBHOOK_DEACTIVATION = "webhook_deactivation"
 # A second envelope format: no top-level event_type, real content nested in
 # `extra_params`. Routed by `_process_device_event`, before `classify()`.
 WEBHOOK_DEVICE_EVENT = "device_event"
+# Structural change (module added / moved to a room / firmware or device
+# update). No top-level event_type; a `change` field names the variant.
+WEBHOOK_TOPOLOGY_CHANGED = "topology_changed"
 CAMERA_CONNECTION_WEBHOOKS = frozenset(
     {"NACamera-connection", "NOC-connection", "NDB-connection"},
 )
@@ -231,6 +234,9 @@ async def process_webhook(
     if push_type == WEBHOOK_DEVICE_EVENT:
         return await _process_device_event(account, payload)
 
+    if push_type == WEBHOOK_TOPOLOGY_CHANGED:
+        return _process_topology_changed(home_id, payload)
+
     return _process_standard_envelope(account, home_id, event_type, push_type, payload)
 
 
@@ -345,6 +351,27 @@ async def _merge_device_modules(
         await module.update(module_data)
         touched.append(module.entity_id)
     return touched
+
+
+def _process_topology_changed(
+    home_id: str | None,
+    payload: dict[str, Any],
+) -> WebhookResult:
+    """Route a `topology_changed` envelope to TOPOLOGY_DIRTY.
+
+    The payload carries a partial `home.modules[]`, but it is not merged: a
+    full `async_update_topology` refresh (signalled by `needs_refresh`) is the
+    authoritative way to pick up structural changes. `event_type` carries the
+    `change` variant; `touched_ids` the module/device ids referenced.
+    """
+    return WebhookResult(
+        home_id,
+        str_or_none(payload.get("change")),
+        WEBHOOK_TOPOLOGY_CHANGED,
+        WebhookKind.TOPOLOGY_DIRTY,
+        touched_ids=_touched_from_payload(payload),
+        needs_refresh=True,
+    )
 
 
 def _process_state(

--- a/src/pyatmo/webhook.py
+++ b/src/pyatmo/webhook.py
@@ -16,7 +16,12 @@ if TYPE_CHECKING:
 
     from pyatmo.account import AsyncAccount
     from pyatmo.home import Home
-    from pyatmo.modules.module import FloodlightMixin, MonitoringMixin
+    from pyatmo.modules.module import (
+        BoilerMixin,
+        FloodlightMixin,
+        MonitoringMixin,
+        ShutterMixin,
+    )
     from pyatmo.room import Room
 
 LOG: logging.Logger = logging.getLogger(__name__)
@@ -30,13 +35,15 @@ EVENT_TYPE_SETPOINT_EVENT = "setpoint_event"
 EVENT_TYPE_THERM_MODE = "therm_mode"
 EVENT_TYPE_SCHEDULE = "schedule"
 EVENT_TYPE_TEMPERATURE_VARIATION_EVENT = "temperature_variation_event"
+EVENT_TYPE_MOTOR_DATA_EVENT = "motor_data_event"
+EVENT_TYPE_BOILER_EVENT = "boiler_event"
 
 WEBHOOK_ACTIVATION = "webhook_activation"
 WEBHOOK_DEACTIVATION = "webhook_deactivation"
 WEBHOOK_DEVICE_EVENT = "device_event"
 WEBHOOK_TOPOLOGY_CHANGED = "topology_changed"
 CAMERA_CONNECTION_WEBHOOKS = frozenset(
-    {"NACamera-connection", "NOC-connection", "NDB-connection"},
+    {"NACamera-connection", "NOC-connection", "NDB-connection", "NPC-connection"},
 )
 
 STATE_EVENT_TYPES = frozenset(
@@ -61,6 +68,16 @@ _ROOM_SETPOINT_KEYS: dict[str, Callable[[Any], Any]] = {
     "cooling_setpoint_temperature": number_or_none,
     "cooling_setpoint_start_time": number_or_none,
     "cooling_setpoint_end_time": number_or_none,
+}
+
+_DEVICE_EVENT_ATTRIBUTE_MAP: dict[str, str] = {
+    "wifi_status": "wifi_strength",
+    "rf_status": "rf_strength",
+    "firmware": "firmware_revision",
+    "pressure_sea": "pressure",
+    "pressure_abs": "absolute_pressure",
+    "noise_current": "noise",
+    "trend_temperature": "temp_trend",
 }
 
 _EXTRA_EVENT_TYPES = frozenset(
@@ -93,6 +110,7 @@ class LifecycleStatus(Enum):
     ACTIVATION = "activation"
     DEACTIVATION = "deactivation"
     CONNECTION = "connection"
+    DISCONNECTION = "disconnection"
 
 
 class RefreshScope(Enum):
@@ -114,6 +132,7 @@ class WebhookEvent:
     device_id: str | None = None
     room_id: str | None = None
     mode: str | None = None
+    boiler_status: bool | None = None
     person_id: str | None = None
     person_name: str | None = None
     is_known: bool | None = None
@@ -149,7 +168,10 @@ def classify(event_type: str | None, push_type: str | None) -> WebhookKind:
     """Route a webhook payload to a WebhookKind by event_type/push_type."""
     if push_type in (WEBHOOK_ACTIVATION, WEBHOOK_DEACTIVATION):
         return WebhookKind.LIFECYCLE
-    if push_type in CAMERA_CONNECTION_WEBHOOKS:
+    if push_type in CAMERA_CONNECTION_WEBHOOKS or event_type in (
+        "connection",
+        "disconnection",
+    ):
         return WebhookKind.LIFECYCLE
     if event_type in STATE_EVENT_TYPES:
         return WebhookKind.STATE
@@ -176,6 +198,14 @@ def _bool_or_none(value: Any) -> bool | None:  # noqa: ANN401
     return value if isinstance(value, bool) else None
 
 
+def _map_boiler_status(raw: Any) -> bool | None:  # noqa: ANN401
+    if raw == "boiler_on":
+        return True
+    if raw == "boiler_off":
+        return False
+    return None
+
+
 def _resolve_person_name(home: Home | None, person_id: str | None) -> str | None:
     if home is None or person_id is None:
         return None
@@ -194,12 +224,14 @@ def _shared_event_fields(
         "event_type": event_type,
         "push_type": push_type,
         "home_id": home_id,
-        "module_id": str_or_none(payload.get("module_id")),
+        "module_id": str_or_none(payload.get("module_id"))
+        or str_or_none(extra.get("module_id")),
         "camera_id": str_or_none(payload.get("camera_id")),
         "device_id": str_or_none(payload.get("device_id")),
         "room_id": str_or_none(payload.get("room_id"))
         or str_or_none(extra.get("room_id")),
         "mode": str_or_none(payload.get("mode")) or str_or_none(extra.get("mode")),
+        "boiler_status": _map_boiler_status(extra.get("boiler_status")),
         "sub_type": str_or_none(payload.get("sub_type")),
         "snapshot_url": str_or_none(payload.get("snapshot_url")),
         "vignette_url": str_or_none(payload.get("vignette_url")),
@@ -322,7 +354,7 @@ def _process_standard_envelope(
     kind = classify(event_type, push_type)
 
     if kind is WebhookKind.LIFECYCLE:
-        return _process_lifecycle(home_id, event_type, push_type)
+        return _process_lifecycle(account, home_id, event_type, push_type, payload)
 
     if kind is WebhookKind.STATE:
         return _process_state(account, home_id, event_type, push_type, payload)
@@ -362,8 +394,9 @@ async def _process_device_event(
 
     event_type = str_or_none(extra.get("event_type"))
     if event_type:
-        # Merge measured temperature only; setpoints stay authoritative via display_change.
-        touched = _merge_device_energy_temperature(account, home_id, event_type, extra)
+        touched = _merge_device_energy_event(
+            account, home_id, payload, event_type, extra
+        )
         return WebhookResult(
             home_id,
             event_type,
@@ -373,6 +406,69 @@ async def _process_device_event(
         )
 
     return WebhookResult(home_id, None, WEBHOOK_DEVICE_EVENT, WebhookKind.UNKNOWN)
+
+
+def _merge_device_energy_event(
+    account: AsyncAccount,
+    home_id: str | None,
+    payload: dict[str, Any],
+    event_type: str,
+    extra: dict[str, Any],
+) -> list[str]:
+    if event_type == EVENT_TYPE_MOTOR_DATA_EVENT:
+        return _merge_motor_data_event(account, home_id, extra)
+    if event_type == EVENT_TYPE_BOILER_EVENT:
+        return _merge_boiler_event(account, home_id, payload, extra)
+    # setpoint_event / temperature_variation_event -- room telemetry merge.
+    # Setpoints stay authoritative via display_change; never merged here.
+    return _merge_device_energy_temperature(account, home_id, event_type, extra)
+
+
+def _merge_motor_data_event(
+    account: AsyncAccount,
+    home_id: str | None,
+    extra: dict[str, Any],
+) -> list[str]:
+    module_id = str_or_none(extra.get("module_id"))
+    if not module_id:
+        return []
+    position = number_or_none(extra.get("current_position"))
+    home = account.homes.get(home_id) if home_id else None
+    module = home.modules.get(module_id) if home is not None else None
+    if module is None or position is None or not hasattr(module, "current_position"):
+        return []
+    cast("ShutterMixin", module).current_position = int(position)
+    return [module_id]
+
+
+def _merge_boiler_event(
+    account: AsyncAccount,
+    home_id: str | None,
+    payload: dict[str, Any],
+    extra: dict[str, Any],
+) -> list[str]:
+    device_id = str_or_none(payload.get("device_id"))
+    fallback = [device_id] if device_id else []
+
+    mapped = _map_boiler_status(extra.get("boiler_status"))
+    home = account.homes.get(home_id) if home_id else None
+    if mapped is None or home is None:
+        return fallback
+
+    boiler_modules = [
+        module for module in home.modules.values() if hasattr(module, "boiler_status")
+    ]
+    target = next(
+        (m for m in boiler_modules if getattr(m, "bridge", None) == device_id),
+        None,
+    )
+    if target is None and len(boiler_modules) == 1:
+        target = boiler_modules[0]
+    if target is None:
+        return fallback
+
+    cast("BoilerMixin", target).boiler_status = mapped
+    return [target.entity_id]
 
 
 def _device_event_measured_temperature(
@@ -402,6 +498,10 @@ def _merge_device_energy_temperature(
     return [room.entity_id]
 
 
+def _normalize_device_event_module(module_data: dict[str, Any]) -> dict[str, Any]:
+    return {_DEVICE_EVENT_ATTRIBUTE_MAP.get(k, k): v for k, v in module_data.items()}
+
+
 async def _merge_device_modules(
     account: AsyncAccount,
     home_id: str | None,
@@ -419,7 +519,7 @@ async def _merge_device_modules(
         if getattr(module, "device_category", None) == DeviceCategory.camera:
             # Camera.update() does network I/O; never run that from a webhook.
             continue
-        await module.update(module_data)
+        await module.update(_normalize_device_event_module(module_data))
         touched.append(module.entity_id)
     return touched
 
@@ -566,25 +666,63 @@ def _process_event(
     )
 
 
+def _is_disconnection(event_type: str | None, push_type: str | None) -> bool:
+    return (
+        event_type == "disconnection"
+        or push_type == "disconnection"
+        or (push_type is not None and push_type.endswith("-disconnection"))
+    )
+
+
 def _process_lifecycle(
+    account: AsyncAccount,
     home_id: str | None,
     event_type: str | None,
     push_type: str | None,
+    payload: dict[str, Any],
 ) -> WebhookResult:
     if push_type == WEBHOOK_ACTIVATION:
-        lifecycle = LifecycleStatus.ACTIVATION
-        refresh_scope = None
-    elif push_type == WEBHOOK_DEACTIVATION:
-        lifecycle = LifecycleStatus.DEACTIVATION
-        refresh_scope = None
-    else:
-        lifecycle = LifecycleStatus.CONNECTION
-        refresh_scope = RefreshScope.STATUS
+        return WebhookResult(
+            home_id,
+            event_type,
+            push_type,
+            WebhookKind.LIFECYCLE,
+            lifecycle=LifecycleStatus.ACTIVATION,
+        )
+    if push_type == WEBHOOK_DEACTIVATION:
+        return WebhookResult(
+            home_id,
+            event_type,
+            push_type,
+            WebhookKind.LIFECYCLE,
+            lifecycle=LifecycleStatus.DEACTIVATION,
+        )
+
+    home = account.homes.get(home_id) if home_id else None
+    camera_id = _camera_id(payload)
+    module = home.modules.get(camera_id) if home is not None and camera_id else None
+    touched = [camera_id] if module is not None else []
+
+    if _is_disconnection(event_type, push_type):
+        if module is not None:
+            module.mark_unreachable()
+        return WebhookResult(
+            home_id,
+            event_type,
+            push_type,
+            WebhookKind.LIFECYCLE,
+            touched_ids=touched,
+            lifecycle=LifecycleStatus.DISCONNECTION,
+        )
+
+    if module is not None:
+        module.mark_reachable()
     return WebhookResult(
         home_id,
         event_type,
         push_type,
         WebhookKind.LIFECYCLE,
-        refresh_scope=refresh_scope,
-        lifecycle=lifecycle,
+        touched_ids=touched,
+        refresh_scope=RefreshScope.STATUS,
+        lifecycle=LifecycleStatus.CONNECTION,
     )

--- a/src/pyatmo/webhook.py
+++ b/src/pyatmo/webhook.py
@@ -38,6 +38,17 @@ EVENT_TYPE_TEMPERATURE_VARIATION_EVENT = "temperature_variation_event"
 EVENT_TYPE_MOTOR_DATA_EVENT = "motor_data_event"
 EVENT_TYPE_BOILER_EVENT = "boiler_event"
 
+# device_event energy `event_type`s with a known merge; anything else with a
+# resolved type (e.g. diagnosis_event) is surfaced as an EVENT, unmerged.
+_DEVICE_ENERGY_EVENT_TYPES = frozenset(
+    {
+        EVENT_TYPE_TEMPERATURE_VARIATION_EVENT,
+        EVENT_TYPE_SETPOINT_EVENT,
+        EVENT_TYPE_MOTOR_DATA_EVENT,
+        EVENT_TYPE_BOILER_EVENT,
+    },
+)
+
 WEBHOOK_ACTIVATION = "webhook_activation"
 WEBHOOK_DEACTIVATION = "webhook_deactivation"
 WEBHOOK_DEVICE_EVENT = "device_event"
@@ -285,8 +296,10 @@ def build_webhook_events(
             for module in modules
         ]
 
-    event_type = str_or_none(payload.get("event_type")) or str_or_none(
-        extra.get("event_type"),
+    event_type = (
+        str_or_none(payload.get("event_type"))
+        or str_or_none(extra.get("event_type"))
+        or str_or_none(extra.get("type"))
     )
     if event_type is None:
         return []
@@ -402,8 +415,9 @@ async def _process_device_event(
             refresh_scope=refresh_scope,
         )
 
-    event_type = str_or_none(extra.get("event_type"))
-    if event_type:
+    event_type = str_or_none(extra.get("event_type")) or str_or_none(extra.get("type"))
+
+    if event_type in _DEVICE_ENERGY_EVENT_TYPES:
         touched, unresolved = _merge_device_energy_event(
             account,
             home_id,
@@ -421,6 +435,18 @@ async def _process_device_event(
             WebhookKind.STATE,
             touched_ids=touched,
             refresh_scope=refresh_scope,
+        )
+
+    if event_type is not None:
+        # Unrecognized device-event type (e.g. diagnosis_event): no known
+        # merge target, surface it as an EVENT instead of dropping it.
+        device_id = str_or_none(payload.get("device_id"))
+        return WebhookResult(
+            home_id,
+            event_type,
+            WEBHOOK_DEVICE_EVENT,
+            WebhookKind.EVENT,
+            touched_ids=[device_id] if device_id else [],
         )
 
     return WebhookResult(home_id, None, WEBHOOK_DEVICE_EVENT, WebhookKind.UNKNOWN)

--- a/src/pyatmo/webhook.py
+++ b/src/pyatmo/webhook.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any, cast
 
 from pyatmo.event import EventTypes
 from pyatmo.helpers import dict_entries, number_or_none, str_or_none
+from pyatmo.modules.device_types import DeviceCategory
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -25,11 +26,17 @@ EVENT_TYPE_OFF = "off"
 EVENT_TYPE_LIGHT_MODE = "light_mode"
 EVENT_TYPE_SET_POINT = "set_point"
 EVENT_TYPE_CANCEL_SET_POINT = "cancel_set_point"
+# Real `display_change` payloads use this name instead of `set_point`; same
+# nested `home.rooms[]` therm_setpoint_* keys, so it is treated as an alias.
+EVENT_TYPE_SETPOINT_EVENT = "setpoint_event"
 EVENT_TYPE_THERM_MODE = "therm_mode"
 EVENT_TYPE_SCHEDULE = "schedule"
 
 WEBHOOK_ACTIVATION = "webhook_activation"
 WEBHOOK_DEACTIVATION = "webhook_deactivation"
+# A second envelope format: no top-level event_type, real content nested in
+# `extra_params`. Routed by `_process_device_event`, before `classify()`.
+WEBHOOK_DEVICE_EVENT = "device_event"
 CAMERA_CONNECTION_WEBHOOKS = frozenset(
     {"NACamera-connection", "NOC-connection", "NDB-connection"},
 )
@@ -41,6 +48,7 @@ STATE_EVENT_TYPES = frozenset(
         EVENT_TYPE_LIGHT_MODE,
         EVENT_TYPE_SET_POINT,
         EVENT_TYPE_CANCEL_SET_POINT,
+        EVENT_TYPE_SETPOINT_EVENT,
         EVENT_TYPE_THERM_MODE,
     },
 )
@@ -155,10 +163,25 @@ def resolve_home_id(payload: dict[str, Any]) -> str | None:
     return str_or_none(payload.get("home_id")) or nested
 
 
+def _extra_params(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return the `device_event` envelope's `extra_params` block, or `{}`.
+
+    That envelope nests its real content here instead of at the top level;
+    callers must tolerate a missing or malformed block without raising.
+    """
+    extra = payload.get("extra_params")
+    return extra if isinstance(extra, dict) else {}
+
+
 def build_webhook_event(payload: dict[str, Any]) -> WebhookEvent:
-    """Build a WebhookEvent from an EVENT-class payload."""
+    """Build a WebhookEvent from an EVENT-class payload.
+
+    `event_type` falls back to `extra_params.event_type` for the
+    `device_event` envelope, which carries no top-level `event_type`.
+    """
     return WebhookEvent(
-        event_type=str_or_none(payload.get("event_type")),
+        event_type=str_or_none(payload.get("event_type"))
+        or str_or_none(_extra_params(payload).get("event_type")),
         push_type=str_or_none(payload.get("push_type")),
         home_id=resolve_home_id(payload),
         module_id=str_or_none(payload.get("module_id")),
@@ -182,10 +205,13 @@ async def process_webhook(
 ) -> WebhookResult:
     """Parse, normalize, and merge a Netatmo webhook payload.
 
-    Performs no I/O and never suspends, because Netatmo requires a webhook
-    endpoint to answer immediately and deactivates one that does not. Do not add
-    an `await` here: it would put network latency, including the 429 backoff in
-    `auth.py`, on the response path.
+    Performs no I/O and never suspends for the standard envelope, because
+    Netatmo requires a webhook endpoint to answer immediately and deactivates
+    one that does not. Do not add an `await` here: it would put network
+    latency, including the 429 backoff in `auth.py`, on the response path. The
+    `device_event` envelope is the one documented exception: its module merge
+    goes through `Module.update`, which is `async` but performs no I/O of its
+    own for the plain (non-Camera) modules it is used for today.
 
     Merging is therefore best-effort. An `async_update_*` call already in flight
     fetched its snapshot before this payload arrived, and will overwrite the
@@ -202,6 +228,25 @@ async def process_webhook(
         LOG.debug("Webhook payload without event_type/push_type: %s", payload)
         return WebhookResult(home_id, event_type, push_type, WebhookKind.UNKNOWN)
 
+    if push_type == WEBHOOK_DEVICE_EVENT:
+        return await _process_device_event(account, payload)
+
+    return _process_standard_envelope(account, home_id, event_type, push_type, payload)
+
+
+def _process_standard_envelope(
+    account: AsyncAccount,
+    home_id: str | None,
+    event_type: str | None,
+    push_type: str | None,
+    payload: dict[str, Any],
+) -> WebhookResult:
+    """Route the standard top-level-`event_type` envelope via `classify()`.
+
+    Split out of `process_webhook` so `device_event` -- which carries no
+    top-level `event_type` and is routed before `classify()` runs -- cannot
+    reach here, keeping `classify()` pure for this envelope shape.
+    """
     kind = classify(event_type, push_type)
 
     if kind is WebhookKind.LIFECYCLE:
@@ -225,6 +270,83 @@ async def process_webhook(
     return WebhookResult(home_id, event_type, push_type, WebhookKind.UNKNOWN)
 
 
+async def _process_device_event(
+    account: AsyncAccount,
+    payload: dict[str, Any],
+) -> WebhookResult:
+    """Route a `device_event` envelope by its `extra_params` contents.
+
+    - `extra_params.modules[]` present -> STATE, merged via `Module.update`
+      (reflection-based, so it keeps attributes absent from the partial
+      payload, unlike `Room.update`).
+    - else `extra_params.event_type` present (energy events such as
+      `setpoint_event`/`temperature_variation_event`) -> EVENT, surfaced only;
+      no state merge. These use a different key schema (`temperature`/
+      `setpoint`/`ts_begin`/`ts_end`, not `therm_setpoint_*`) than the
+      top-level `display_change` payload Netatmo also sends for the same
+      change, which is the authoritative, cleanly-keyed source for the room
+      merge -- merging both would double-apply.
+    - else -> UNKNOWN, no mutation.
+    """
+    extra = _extra_params(payload)
+    home_id = resolve_home_id(payload)
+    modules = dict_entries(extra.get("modules"))
+
+    if modules:
+        touched = await _merge_device_modules(account, home_id, modules)
+        return WebhookResult(
+            home_id,
+            str_or_none(extra.get("event_type")),
+            WEBHOOK_DEVICE_EVENT,
+            WebhookKind.STATE,
+            touched_ids=touched,
+        )
+
+    event_type = str_or_none(extra.get("event_type"))
+    if event_type:
+        device_id = str_or_none(payload.get("device_id"))
+        return WebhookResult(
+            home_id,
+            event_type,
+            WEBHOOK_DEVICE_EVENT,
+            WebhookKind.EVENT,
+            touched_ids=[device_id] if device_id else [],
+            events=[build_webhook_event(payload)],
+        )
+
+    return WebhookResult(home_id, None, WEBHOOK_DEVICE_EVENT, WebhookKind.UNKNOWN)
+
+
+async def _merge_device_modules(
+    account: AsyncAccount,
+    home_id: str | None,
+    modules: list[dict[str, Any]],
+) -> list[str]:
+    """Merge each module via `Module.update`, a safe partial merge.
+
+    Unlike `Room.update`, `Module.update` is reflection-based and preserves
+    attributes absent from the partial payload. Camera-category modules are
+    skipped: `Camera.update` calls `async_update_camera_urls`, which performs
+    network I/O and must never run on the webhook response path. Current
+    `device_event` payloads only carry dimmers/switches, but this guards
+    defensively against a future payload naming a camera.
+    """
+    home = account.homes.get(home_id) if home_id else None
+    if home is None:
+        return []
+    touched: list[str] = []
+    for module_data in modules:
+        module_id = str_or_none(module_data.get("id"))
+        module = home.modules.get(module_id) if module_id else None
+        if module is None:
+            continue
+        if getattr(module, "device_category", None) == DeviceCategory.camera:
+            continue
+        await module.update(module_data)
+        touched.append(module.entity_id)
+    return touched
+
+
 def _process_state(
     account: AsyncAccount,
     home_id: str | None,
@@ -238,7 +360,11 @@ def _process_state(
         return WebhookResult(home_id, event_type, push_type, WebhookKind.STATE)
 
     touched: list[str] = []
-    if event_type in (EVENT_TYPE_SET_POINT, EVENT_TYPE_CANCEL_SET_POINT):
+    if event_type in (
+        EVENT_TYPE_SET_POINT,
+        EVENT_TYPE_CANCEL_SET_POINT,
+        EVENT_TYPE_SETPOINT_EVENT,
+    ):
         touched = _merge_rooms(home, payload)
     elif event_type == EVENT_TYPE_THERM_MODE:
         home_data = payload.get("home")

--- a/src/pyatmo/webhook.py
+++ b/src/pyatmo/webhook.py
@@ -100,6 +100,18 @@ class LifecycleStatus(Enum):
     CONNECTION = "connection"
 
 
+class RefreshScope(Enum):
+    """Which poll a consumer should run to reconcile after a webhook.
+
+    TOPOLOGY -> async_update_topology (/homesdata): structural or schedule
+    changes. STATUS -> async_update_status (/homestatus): live device state,
+    e.g. after a camera reconnect.
+    """
+
+    TOPOLOGY = "topology"
+    STATUS = "status"
+
+
 @dataclass(frozen=True)
 class WebhookEvent:
     """A parsed webhook event (distinct from the /getevents Event stream).
@@ -140,8 +152,13 @@ class WebhookResult:
     kind: WebhookKind
     touched_ids: list[str] = field(default_factory=list)
     events: list[WebhookEvent] = field(default_factory=list)
-    needs_refresh: bool = False
+    refresh_scope: RefreshScope | None = None
     lifecycle: LifecycleStatus | None = None
+
+    @property
+    def needs_refresh(self) -> bool:
+        """True when the consumer should poll; see `refresh_scope` for which."""
+        return self.refresh_scope is not None
 
 
 def classify(event_type: str | None, push_type: str | None) -> WebhookKind:
@@ -270,7 +287,7 @@ def _process_standard_envelope(
             event_type,
             push_type,
             WebhookKind.TOPOLOGY_DIRTY,
-            needs_refresh=True,
+            refresh_scope=RefreshScope.TOPOLOGY,
         )
 
     return WebhookResult(home_id, event_type, push_type, WebhookKind.UNKNOWN)
@@ -370,7 +387,7 @@ def _process_topology_changed(
         WEBHOOK_TOPOLOGY_CHANGED,
         WebhookKind.TOPOLOGY_DIRTY,
         touched_ids=_touched_from_payload(payload),
-        needs_refresh=True,
+        refresh_scope=RefreshScope.TOPOLOGY,
     )
 
 
@@ -518,18 +535,18 @@ def _process_lifecycle(
 ) -> WebhookResult:
     if push_type == WEBHOOK_ACTIVATION:
         lifecycle = LifecycleStatus.ACTIVATION
-        needs_refresh = False
+        refresh_scope = None
     elif push_type == WEBHOOK_DEACTIVATION:
         lifecycle = LifecycleStatus.DEACTIVATION
-        needs_refresh = False
+        refresh_scope = None
     else:  # camera reconnect
         lifecycle = LifecycleStatus.CONNECTION
-        needs_refresh = True
+        refresh_scope = RefreshScope.STATUS
     return WebhookResult(
         home_id,
         event_type,
         push_type,
         WebhookKind.LIFECYCLE,
-        needs_refresh=needs_refresh,
+        refresh_scope=refresh_scope,
         lifecycle=lifecycle,
     )

--- a/src/pyatmo/webhook.py
+++ b/src/pyatmo/webhook.py
@@ -1,0 +1,382 @@
+"""Support for processing Netatmo webhook payloads."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+import logging
+from typing import TYPE_CHECKING, Any, cast
+
+from pyatmo.event import EventTypes
+from pyatmo.helpers import dict_entries, number_or_none, str_or_none
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from pyatmo.account import AsyncAccount
+    from pyatmo.home import Home
+    from pyatmo.modules.module import FloodlightMixin, MonitoringMixin
+    from pyatmo.room import Room
+
+LOG: logging.Logger = logging.getLogger(__name__)
+
+EVENT_TYPE_ON = "on"
+EVENT_TYPE_OFF = "off"
+EVENT_TYPE_LIGHT_MODE = "light_mode"
+EVENT_TYPE_SET_POINT = "set_point"
+EVENT_TYPE_CANCEL_SET_POINT = "cancel_set_point"
+EVENT_TYPE_THERM_MODE = "therm_mode"
+EVENT_TYPE_SCHEDULE = "schedule"
+
+WEBHOOK_ACTIVATION = "webhook_activation"
+WEBHOOK_DEACTIVATION = "webhook_deactivation"
+CAMERA_CONNECTION_WEBHOOKS = frozenset(
+    {"NACamera-connection", "NOC-connection", "NDB-connection"},
+)
+
+STATE_EVENT_TYPES = frozenset(
+    {
+        EVENT_TYPE_ON,
+        EVENT_TYPE_OFF,
+        EVENT_TYPE_LIGHT_MODE,
+        EVENT_TYPE_SET_POINT,
+        EVENT_TYPE_CANCEL_SET_POINT,
+        EVENT_TYPE_THERM_MODE,
+    },
+)
+
+_ROOM_SETPOINT_KEYS: dict[str, Callable[[Any], Any]] = {
+    "therm_setpoint_mode": str_or_none,
+    "therm_setpoint_fp": str_or_none,
+    "therm_setpoint_temperature": number_or_none,
+    "therm_setpoint_start_time": number_or_none,
+    "therm_setpoint_end_time": number_or_none,
+    "cooling_setpoint_mode": str_or_none,
+    "cooling_setpoint_temperature": number_or_none,
+    "cooling_setpoint_start_time": number_or_none,
+    "cooling_setpoint_end_time": number_or_none,
+}
+
+_EXTRA_EVENT_TYPES = frozenset(
+    {
+        "human",
+        "animal",
+        "vehicle",
+        "alarm_started",
+    },
+)
+
+EVENT_EVENT_TYPES = (
+    frozenset(event_type.value for event_type in EventTypes) | _EXTRA_EVENT_TYPES
+) - STATE_EVENT_TYPES
+
+
+class WebhookKind(Enum):
+    """Category a webhook payload was routed to."""
+
+    STATE = "state"
+    EVENT = "event"
+    TOPOLOGY_DIRTY = "topology_dirty"
+    LIFECYCLE = "lifecycle"
+    UNKNOWN = "unknown"
+
+
+class LifecycleStatus(Enum):
+    """Lifecycle status for LIFECYCLE-kind payloads."""
+
+    ACTIVATION = "activation"
+    DEACTIVATION = "deactivation"
+    CONNECTION = "connection"
+
+
+@dataclass(frozen=True)
+class WebhookEvent:
+    """A parsed webhook event (distinct from the /getevents Event stream).
+
+    `frozen` prevents rebinding an attribute but not mutating one: `person_ids`
+    and `raw` stay mutable, so instances are not hashable and `hash()` or set
+    membership raises `TypeError`. Compare them by value instead.
+    """
+
+    event_type: str | None
+    push_type: str | None
+    home_id: str | None
+    module_id: str | None = None
+    camera_id: str | None = None
+    device_id: str | None = None
+    person_ids: list[str] = field(default_factory=list)
+    sub_type: str | None = None
+    snapshot_url: str | None = None
+    message: str | None = None
+    raw: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class WebhookResult:
+    """Outcome of processing one webhook payload.
+
+    Not hashable, for the same reason as `WebhookEvent`: `touched_ids` and
+    `events` stay mutable despite `frozen`. Compare by value instead.
+
+    The `touched_ids` namespace depends on `event_type` -- room ids for
+    set_point and cancel_set_point, the home id for therm_mode, module ids for
+    on/off, light_mode and EVENT payloads.
+    """
+
+    home_id: str | None
+    event_type: str | None
+    push_type: str | None
+    kind: WebhookKind
+    touched_ids: list[str] = field(default_factory=list)
+    events: list[WebhookEvent] = field(default_factory=list)
+    needs_refresh: bool = False
+    lifecycle: LifecycleStatus | None = None
+
+
+def classify(event_type: str | None, push_type: str | None) -> WebhookKind:
+    """Route a webhook payload to a WebhookKind by event_type/push_type."""
+    if push_type in (WEBHOOK_ACTIVATION, WEBHOOK_DEACTIVATION):
+        return WebhookKind.LIFECYCLE
+    if push_type in CAMERA_CONNECTION_WEBHOOKS:
+        return WebhookKind.LIFECYCLE
+    if event_type in STATE_EVENT_TYPES:
+        return WebhookKind.STATE
+    if event_type == EVENT_TYPE_SCHEDULE:
+        return WebhookKind.TOPOLOGY_DIRTY
+    if event_type in EVENT_EVENT_TYPES:
+        return WebhookKind.EVENT
+    return WebhookKind.UNKNOWN
+
+
+def resolve_home_id(payload: dict[str, Any]) -> str | None:
+    """Return the home id from either the top-level or nested `home` block."""
+    home = payload.get("home")
+    nested = str_or_none(home.get("id")) if isinstance(home, dict) else None
+    return str_or_none(payload.get("home_id")) or nested
+
+
+def build_webhook_event(payload: dict[str, Any]) -> WebhookEvent:
+    """Build a WebhookEvent from an EVENT-class payload."""
+    return WebhookEvent(
+        event_type=str_or_none(payload.get("event_type")),
+        push_type=str_or_none(payload.get("push_type")),
+        home_id=resolve_home_id(payload),
+        module_id=str_or_none(payload.get("module_id")),
+        camera_id=str_or_none(payload.get("camera_id")),
+        device_id=str_or_none(payload.get("device_id")),
+        person_ids=[
+            person_id
+            for person in dict_entries(payload.get("persons"))
+            if (person_id := str_or_none(person.get("id")))
+        ],
+        sub_type=str_or_none(payload.get("sub_type")),
+        snapshot_url=str_or_none(payload.get("snapshot_url")),
+        message=str_or_none(payload.get("message")),
+        raw=payload,
+    )
+
+
+async def process_webhook(
+    account: AsyncAccount,
+    payload: dict[str, Any],
+) -> WebhookResult:
+    """Parse, normalize, and merge a Netatmo webhook payload.
+
+    Performs no I/O and never suspends, because Netatmo requires a webhook
+    endpoint to answer immediately and deactivates one that does not. Do not add
+    an `await` here: it would put network latency, including the 429 backoff in
+    `auth.py`, on the response path.
+
+    Merging is therefore best-effort. An `async_update_*` call already in flight
+    fetched its snapshot before this payload arrived, and will overwrite the
+    merge when it completes; the next successful poll restores the true state,
+    since the server is authoritative. Callers that need the merge to survive
+    should answer the webhook first and then apply the result in a task ordered
+    after any in-flight refresh -- `needs_refresh` schedules that follow-up.
+    """
+    event_type = str_or_none(payload.get("event_type"))
+    push_type = str_or_none(payload.get("push_type"))
+    home_id = resolve_home_id(payload)
+
+    if not event_type and not push_type:
+        LOG.debug("Webhook payload without event_type/push_type: %s", payload)
+        return WebhookResult(home_id, event_type, push_type, WebhookKind.UNKNOWN)
+
+    kind = classify(event_type, push_type)
+
+    if kind is WebhookKind.LIFECYCLE:
+        return _process_lifecycle(home_id, event_type, push_type)
+
+    if kind is WebhookKind.STATE:
+        return _process_state(account, home_id, event_type, push_type, payload)
+
+    if kind is WebhookKind.EVENT:
+        return _process_event(home_id, event_type, push_type, payload)
+
+    if kind is WebhookKind.TOPOLOGY_DIRTY:
+        return WebhookResult(
+            home_id,
+            event_type,
+            push_type,
+            WebhookKind.TOPOLOGY_DIRTY,
+            needs_refresh=True,
+        )
+
+    return WebhookResult(home_id, event_type, push_type, WebhookKind.UNKNOWN)
+
+
+def _process_state(
+    account: AsyncAccount,
+    home_id: str | None,
+    event_type: str | None,
+    push_type: str | None,
+    payload: dict[str, Any],
+) -> WebhookResult:
+    home = account.homes.get(home_id) if home_id else None
+    if home_id is None or home is None:
+        LOG.debug("Webhook STATE payload for unknown home %s; skipping", home_id)
+        return WebhookResult(home_id, event_type, push_type, WebhookKind.STATE)
+
+    touched: list[str] = []
+    if event_type in (EVENT_TYPE_SET_POINT, EVENT_TYPE_CANCEL_SET_POINT):
+        touched = _merge_rooms(home, payload)
+    elif event_type == EVENT_TYPE_THERM_MODE:
+        home_data = payload.get("home")
+        therm_mode = (
+            str_or_none(home_data.get("therm_mode"))
+            if isinstance(home_data, dict)
+            else None
+        )
+        if therm_mode is not None:
+            home.therm_mode = therm_mode
+            touched = [home_id]
+    elif event_type in (EVENT_TYPE_ON, EVENT_TYPE_OFF):
+        touched = _merge_camera_monitoring(home, event_type, payload)
+    elif event_type == EVENT_TYPE_LIGHT_MODE:
+        touched = _merge_camera_floodlight(home, payload)
+
+    return WebhookResult(
+        home_id,
+        event_type,
+        push_type,
+        WebhookKind.STATE,
+        touched_ids=touched,
+    )
+
+
+def _merge_rooms(home: Home, payload: dict[str, Any]) -> list[str]:
+    """Merge only the setpoint fields present in the payload into each room."""
+    touched: list[str] = []
+    home_data = payload.get("home")
+    if not isinstance(home_data, dict):
+        return touched
+    for room in dict_entries(home_data.get("rooms")):
+        room_id = str_or_none(room.get("id"))
+        room_obj = home.rooms.get(room_id) if room_id else None
+        if room_obj is None:
+            continue
+        if _merge_room_setpoints(room_obj, room):
+            touched.append(room_obj.entity_id)
+    return touched
+
+
+def _merge_room_setpoints(room_obj: Room, room: dict[str, Any]) -> bool:
+    """Apply the payload's setpoint fields to `room_obj`; return True if any stuck.
+
+    An explicit `null` is honoured and clears the field, since that is how a
+    cancelled setpoint arrives. A value of the wrong type is dropped instead,
+    so a malformed payload cannot overwrite a known-good reading.
+    """
+    applied = False
+    for key, coerce in _ROOM_SETPOINT_KEYS.items():
+        if key not in room:
+            continue
+        raw = room[key]
+        value = coerce(raw)
+        if value is None and raw is not None:
+            continue
+        setattr(room_obj, key, value)
+        applied = True
+    return applied
+
+
+def _camera_id(payload: dict[str, Any]) -> str | None:
+    camera_id = str_or_none(payload.get("camera_id"))
+    return camera_id or str_or_none(payload.get("device_id"))
+
+
+def _merge_camera_monitoring(
+    home: Home,
+    event_type: str | None,
+    payload: dict[str, Any],
+) -> list[str]:
+    camera_id = _camera_id(payload)
+    if not camera_id:
+        return []
+    module = home.modules.get(camera_id)
+    if module is None or not hasattr(module, "monitoring"):
+        return []
+    cast("MonitoringMixin", module).monitoring = event_type == EVENT_TYPE_ON
+    return [camera_id]
+
+
+def _merge_camera_floodlight(home: Home, payload: dict[str, Any]) -> list[str]:
+    camera_id = _camera_id(payload)
+    if not camera_id:
+        return []
+    module = home.modules.get(camera_id)
+    sub_type = str_or_none(payload.get("sub_type"))
+    if module is None or sub_type is None or not hasattr(module, "floodlight"):
+        return []
+    cast("FloodlightMixin", module).floodlight = sub_type
+    return [camera_id]
+
+
+def _touched_from_payload(payload: dict[str, Any]) -> list[str]:
+    """De-duplicated device/camera/module ids referenced by the payload."""
+    ids: list[str] = []
+    for key in ("device_id", "camera_id", "module_id"):
+        value = str_or_none(payload.get(key))
+        if value and value not in ids:
+            ids.append(value)
+    return ids
+
+
+def _process_event(
+    home_id: str | None,
+    event_type: str | None,
+    push_type: str | None,
+    payload: dict[str, Any],
+) -> WebhookResult:
+    return WebhookResult(
+        home_id,
+        event_type,
+        push_type,
+        WebhookKind.EVENT,
+        touched_ids=_touched_from_payload(payload),
+        events=[build_webhook_event(payload)],
+    )
+
+
+def _process_lifecycle(
+    home_id: str | None,
+    event_type: str | None,
+    push_type: str | None,
+) -> WebhookResult:
+    if push_type == WEBHOOK_ACTIVATION:
+        lifecycle = LifecycleStatus.ACTIVATION
+        needs_refresh = False
+    elif push_type == WEBHOOK_DEACTIVATION:
+        lifecycle = LifecycleStatus.DEACTIVATION
+        needs_refresh = False
+    else:  # camera reconnect
+        lifecycle = LifecycleStatus.CONNECTION
+        needs_refresh = True
+    return WebhookResult(
+        home_id,
+        event_type,
+        push_type,
+        WebhookKind.LIFECYCLE,
+        needs_refresh=needs_refresh,
+        lifecycle=lifecycle,
+    )

--- a/src/pyatmo/webhook.py
+++ b/src/pyatmo/webhook.py
@@ -803,6 +803,12 @@ def _is_disconnection(event_type: str | None, push_type: str | None) -> bool:
     )
 
 
+_PUSH_LIFECYCLE: dict[str | None, LifecycleStatus] = {
+    WEBHOOK_ACTIVATION: LifecycleStatus.ACTIVATION,
+    WEBHOOK_DEACTIVATION: LifecycleStatus.DEACTIVATION,
+}
+
+
 def _process_lifecycle(
     account: AsyncAccount,
     home_id: str | None,
@@ -810,23 +816,26 @@ def _process_lifecycle(
     push_type: str | None,
     payload: dict[str, Any],
 ) -> WebhookResult:
-    if push_type == WEBHOOK_ACTIVATION:
+    lifecycle = _PUSH_LIFECYCLE.get(push_type)
+    if lifecycle is not None:
         return WebhookResult(
             home_id,
             event_type,
             push_type,
             WebhookKind.LIFECYCLE,
-            lifecycle=LifecycleStatus.ACTIVATION,
+            lifecycle=lifecycle,
         )
-    if push_type == WEBHOOK_DEACTIVATION:
-        return WebhookResult(
-            home_id,
-            event_type,
-            push_type,
-            WebhookKind.LIFECYCLE,
-            lifecycle=LifecycleStatus.DEACTIVATION,
-        )
+    return _process_connectivity(account, home_id, event_type, push_type, payload)
 
+
+def _process_connectivity(
+    account: AsyncAccount,
+    home_id: str | None,
+    event_type: str | None,
+    push_type: str | None,
+    payload: dict[str, Any],
+) -> WebhookResult:
+    """Merge camera reachability from a connection/disconnection webhook."""
     home = account.homes.get(home_id) if home_id else None
     camera_id = _camera_id(payload)
     module = home.modules.get(camera_id) if home is not None and camera_id else None

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,167 @@
+"""Define tests for the helpers module."""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from pyatmo.helpers import dict_entries, fix_id, number_or_none, str_or_none
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ([], []),
+        ([{"id": "a"}], [{"id": "a"}]),
+        ([{"id": "a"}, {"id": "b"}], [{"id": "a"}, {"id": "b"}]),
+        ([{"id": "a"}, "junk", 1, None, ["nested"]], [{"id": "a"}]),
+        (["junk"], []),
+        (None, []),
+        ("junk", []),
+        (1, []),
+        ({"id": "a"}, []),
+    ],
+)
+def test_dict_entries(value, expected):
+    """Only dict entries of a list survive; non-lists collapse to empty."""
+    assert dict_entries(value) == expected
+
+
+def test_dict_entries_preserves_identity():
+    """Entries are the original dicts, so in-place mutation propagates."""
+    entry = {"id": "a"}
+    raw = [entry, "junk"]
+
+    result = dict_entries(raw)
+
+    assert result[0] is entry
+    result[0]["id"] = "b"
+    assert entry["id"] == "b"
+
+
+def test_fix_id_strips_spaces_from_station_and_module_ids():
+    """Superfluous spaces are stripped from station and module ids."""
+    raw_data = [{"_id": "aa bb", "modules": [{"_id": "cc dd"}]}]
+
+    assert fix_id(raw_data) == [{"_id": "aabb", "modules": [{"_id": "ccdd"}]}]
+
+
+def test_fix_id_mutates_in_place():
+    """The input list is mutated and returned, not copied."""
+    station = {"_id": "aa bb"}
+    raw_data = [station]
+
+    assert fix_id(raw_data) is raw_data
+    assert station["_id"] == "aabb"
+
+
+@pytest.mark.parametrize(
+    "raw_data",
+    [
+        [],
+        None,
+        ["only", "strings"],
+        [{"no_id": 1}],
+        [{"_id": None}],
+        [{"_id": "x", "modules": []}],
+    ],
+)
+def test_fix_id_tolerates_entries_without_ids(raw_data):
+    """Non-dict entries and stations without an `_id` are passed through."""
+    before = repr(raw_data)
+
+    assert fix_id(raw_data) == raw_data
+    assert repr(raw_data) == before  # unchanged
+
+
+def test_fix_id_skips_non_dict_entries_but_fixes_the_rest():
+    """A mixed list still gets its dict entries fixed."""
+    raw_data = [{"_id": "aa bb"}, "junk", {"no_id": 1}]
+
+    assert fix_id(raw_data) == [{"_id": "aabb"}, "junk", {"no_id": 1}]
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("abc", "abc"),
+        ("", ""),
+        (None, None),
+        (7, None),
+        (0, None),
+        (True, None),
+        (1.5, None),
+        (b"abc", None),
+        ([1], None),
+        ({"a": 1}, None),
+    ],
+)
+def test_str_or_none(value, expected):
+    """Strings pass through untouched; every other type collapses to None."""
+    assert str_or_none(value) == expected
+
+
+def test_str_or_none_logs_discarded_value(caplog):
+    """A wrongly-typed value is reported, so a bad payload is not invisible."""
+    with caplog.at_level(logging.DEBUG, logger="pyatmo.helpers"):
+        assert str_or_none({"a": 1}) is None
+
+    assert "{'a': 1}" in caplog.text
+
+
+def test_str_or_none_stays_quiet_for_absent_value(caplog):
+    """`None` means absent, which is normal and must not be logged."""
+    with caplog.at_level(logging.DEBUG, logger="pyatmo.helpers"):
+        assert str_or_none(None) is None
+
+    assert caplog.text == ""
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (21, 21),
+        (21.5, 21.5),
+        (0, 0),
+        (-5, -5),
+        (None, None),
+        (True, None),
+        (False, None),
+        ("21", None),
+        ("hot", None),
+        ([1], None),
+        ({"a": 1}, None),
+    ],
+)
+def test_number_or_none(value, expected):
+    """Real numbers pass through; bool and every other type collapse to None."""
+    assert number_or_none(value) == expected
+
+
+def test_number_or_none_rejects_bool_despite_int_subclass():
+    """`bool` is an `int` subclass but never a real measurement."""
+    assert number_or_none(True) is None
+    assert number_or_none(False) is None
+
+
+def test_number_or_none_keeps_falsy_zero():
+    """`0` is a valid measurement and must survive a truthiness-free check."""
+    assert number_or_none(0) == 0
+    assert number_or_none(0.0) == 0.0
+
+
+def test_number_or_none_logs_discarded_value(caplog):
+    """A wrongly-typed value is reported, so a bad payload is not invisible."""
+    with caplog.at_level(logging.DEBUG, logger="pyatmo.helpers"):
+        assert number_or_none("hot") is None
+
+    assert "'hot'" in caplog.text
+
+
+def test_number_or_none_stays_quiet_for_absent_value(caplog):
+    """`None` means absent, which is normal and must not be logged."""
+    with caplog.at_level(logging.DEBUG, logger="pyatmo.helpers"):
+        assert number_or_none(None) is None
+
+    assert caplog.text == ""

--- a/tests/test_reachability_rules.py
+++ b/tests/test_reachability_rules.py
@@ -204,6 +204,27 @@ async def test_propagation_writes_nothing_onto_sub_modules(async_home):
         assert async_home.modules[sub_meter_id]._reachable is None, sub_meter_id  # noqa: SLF001
 
 
+async def test_mark_reachable_propagates_to_bridged_children(async_home):
+    """`mark_reachable()` stamps True definitively, unlike `clear_unreachable()`.
+
+    A reconnect webhook is itself proof of reachability, not merely grounds to
+    defer to the next payload, so this differs from `clear_unreachable()` in the
+    value it writes but shares its propagation walk: bridged children follow,
+    `#`-suffixed sub-modules are skipped and resolve from the parent on read.
+    """
+    ecometer = async_home.modules[ECOMETER]
+    ecometer.mark_unreachable()
+    assert ecometer.reachable is False
+
+    ecometer.mark_reachable()
+
+    assert ecometer.reachable is True
+    for sub_meter_id in SUB_METERS:
+        sub_meter = async_home.modules[sub_meter_id]
+        assert sub_meter._reachable is None, sub_meter_id  # noqa: SLF001
+        assert sub_meter.reachable is True, sub_meter_id
+
+
 async def test_mark_unreachable_survives_a_cycle_in_modules_bridged(async_home):
     """`modules_bridged` is unvalidated API data, so the walk must tolerate a cycle.
 

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -1589,6 +1589,7 @@ async def test_process_webhook_device_event_empty_extra_params(async_account):
 
     assert result.kind is WebhookKind.UNKNOWN
     assert result.refresh_scope == frozenset()
+    assert result.events == []
 
 
 @pytest.mark.usefixtures("async_home")
@@ -1768,3 +1769,36 @@ async def test_process_webhook_device_event_boiler_off_maps_false(async_account)
     result = await process_webhook(async_account, payload)
 
     assert result.events[0].boiler_status is False
+
+
+async def test_process_webhook_device_event_diagnosis_event_surfaces(async_account):
+    """Real capture, redacted: `type`-keyed device_event surfaces as EVENT, no merge."""
+    home_id = "91763b24c43d3e344f424e8b"
+    module_count_before = len(async_account.homes[home_id].modules)
+
+    payload = {
+        "extra_params": {
+            "type": "diagnosis_event",
+            "diagnosis_content": {
+                "modules": [
+                    {
+                        "firmware_revision": 62,
+                        "id": "12:34:56:00:01:34:64:98",
+                        "type": "NLPM",
+                    },
+                ],
+                "type": "ota_limit_reached",
+            },
+        },
+        "push_type": "device_event",
+        "device_id": "12:34:56:3c:63:b2",
+        "home_id": home_id,
+    }
+    result = await process_webhook(async_account, payload)
+
+    assert result.kind is WebhookKind.EVENT
+    assert len(result.events) == 1
+    assert result.events[0].event_type == "diagnosis_event"
+    assert result.touched_ids == ["12:34:56:3c:63:b2"]
+    assert result.refresh_scope == frozenset()
+    assert len(async_account.homes[home_id].modules) == module_count_before

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -31,7 +31,7 @@ def test_webhook_result_defaults():
     assert result.touched_ids == []
     assert result.events == []
     assert result.needs_refresh is False
-    assert result.refresh_scope is None
+    assert result.refresh_scope == frozenset()
     assert result.lifecycle is None
 
 
@@ -139,7 +139,7 @@ async def test_process_webhook_activation(async_account):
     assert result.kind is WebhookKind.LIFECYCLE
     assert result.lifecycle is LifecycleStatus.ACTIVATION
     assert result.needs_refresh is False
-    assert result.refresh_scope is None
+    assert result.refresh_scope == frozenset()
     assert result.events == []
 
 
@@ -151,7 +151,7 @@ async def test_process_webhook_deactivation(async_account):
     assert result.kind is WebhookKind.LIFECYCLE
     assert result.lifecycle is LifecycleStatus.DEACTIVATION
     assert result.needs_refresh is False
-    assert result.refresh_scope is None
+    assert result.refresh_scope == frozenset()
     assert result.events == []
 
 
@@ -164,7 +164,7 @@ async def test_process_webhook_camera_connection_needs_refresh(async_account):
     assert result.kind is WebhookKind.LIFECYCLE
     assert result.lifecycle is LifecycleStatus.CONNECTION
     assert result.needs_refresh is True
-    assert result.refresh_scope is RefreshScope.STATUS
+    assert result.refresh_scope == frozenset({RefreshScope.STATUS})
     assert result.events == []
 
 
@@ -193,7 +193,7 @@ async def test_process_webhook_npc_connection_bare(async_account):
     result = await process_webhook(async_account, {"push_type": "NPC-connection"})
     assert result.kind is WebhookKind.LIFECYCLE
     assert result.lifecycle is LifecycleStatus.CONNECTION
-    assert result.refresh_scope is RefreshScope.STATUS
+    assert result.refresh_scope == frozenset({RefreshScope.STATUS})
     assert result.events == []
 
 
@@ -219,7 +219,7 @@ async def test_process_webhook_camera_disconnection_then_connection_flips_reacha
     )
     assert result.kind is WebhookKind.LIFECYCLE
     assert result.lifecycle is LifecycleStatus.DISCONNECTION
-    assert result.refresh_scope is None
+    assert result.refresh_scope == frozenset()
     assert camera.reachable is False
     assert result.touched_ids == [camera_id]
     assert len(result.events) == 1
@@ -237,7 +237,7 @@ async def test_process_webhook_camera_disconnection_then_connection_flips_reacha
     )
     assert result.kind is WebhookKind.LIFECYCLE
     assert result.lifecycle is LifecycleStatus.CONNECTION
-    assert result.refresh_scope is RefreshScope.STATUS
+    assert result.refresh_scope == frozenset({RefreshScope.STATUS})
     assert camera.reachable is True
     assert result.touched_ids == [camera_id]
     assert len(result.events) == 1
@@ -245,17 +245,21 @@ async def test_process_webhook_camera_disconnection_then_connection_flips_reacha
 
 
 async def test_process_webhook_unknown(async_account):
+    """An unrecognized event_type still surfaces as an event (S5)."""
     result = await process_webhook(
         async_account,
-        {"event_type": "brand_new", "push_type": "brand_new_push"},
+        {"event_type": "brand_new_thing", "push_type": "brand_new_push"},
     )
     assert result.kind is WebhookKind.UNKNOWN
     assert result.touched_ids == []
+    assert len(result.events) == 1
+    assert result.events[0].event_type == "brand_new_thing"
 
 
 async def test_process_webhook_malformed_no_event(async_account):
     result = await process_webhook(async_account, {})
     assert result.kind is WebhookKind.UNKNOWN
+    assert result.events == []
 
 
 async def test_process_webhook_person_event(async_account):
@@ -292,7 +296,7 @@ async def test_process_webhook_movement_event(async_account):
     assert result.kind is WebhookKind.EVENT
     assert result.events[0].event_type == "movement"
     assert result.touched_ids == ["12:34:56:00:f1:62"]
-    assert result.refresh_scope is None
+    assert result.refresh_scope == frozenset()
 
 
 async def test_process_webhook_camera_human_event(async_account):
@@ -460,6 +464,27 @@ async def test_process_webhook_set_point_partial_room_match(async_account):
     assert result.kind is WebhookKind.STATE
     assert result.touched_ids == ["2746182631"]
     assert room.therm_setpoint_mode == "manual"
+    assert result.refresh_scope == frozenset()
+
+
+@pytest.mark.usefixtures("async_home")
+async def test_process_webhook_set_point_unknown_room_self_heals(async_account):
+    """A room id that doesn't match any known room adds TOPOLOGY (S4)."""
+    home_id = "91763b24c43d3e344f424e8b"
+
+    payload = {
+        "event_type": "set_point",
+        "home": {
+            "id": home_id,
+            "rooms": [{"id": "does-not-exist", "therm_setpoint_mode": "manual"}],
+        },
+        "push_type": "display_change",
+    }
+    result = await process_webhook(async_account, payload)
+
+    assert result.kind is WebhookKind.STATE
+    assert result.touched_ids == []
+    assert result.refresh_scope == frozenset({RefreshScope.TOPOLOGY})
 
 
 @pytest.mark.usefixtures("async_home")
@@ -480,9 +505,12 @@ async def test_process_webhook_set_point_without_usable_home_block(
 
     assert result.kind is WebhookKind.STATE
     assert result.touched_ids == []
+    # Malformed/missing home block -- not evidence of a stale topology.
+    assert result.refresh_scope == frozenset()
 
 
 async def test_process_webhook_set_point_unknown_home_no_mutation(async_account):
+    """An unknown home_id self-heals with a TOPOLOGY refresh (S4)."""
     payload = {
         "home": {"id": "does-not-exist", "rooms": [{"id": "r1"}], "modules": []},
         "event_type": "set_point",
@@ -491,6 +519,7 @@ async def test_process_webhook_set_point_unknown_home_no_mutation(async_account)
     result = await process_webhook(async_account, payload)
     assert result.kind is WebhookKind.STATE
     assert result.touched_ids == []
+    assert result.refresh_scope == frozenset({RefreshScope.TOPOLOGY})
 
 
 @pytest.mark.usefixtures("async_home")
@@ -511,7 +540,7 @@ async def test_process_webhook_therm_mode_updates_home(async_account):
     assert result.kind is WebhookKind.STATE
     assert result.touched_ids == [home_id]
     assert home.therm_mode == "hg"
-    assert result.refresh_scope is None
+    assert result.refresh_scope == frozenset({RefreshScope.STATUS})
 
 
 @pytest.mark.usefixtures("async_home")
@@ -563,6 +592,7 @@ async def test_process_webhook_therm_mode_without_mode_touches_nothing(
     assert result.kind is WebhookKind.STATE
     assert result.touched_ids == []
     assert home.therm_mode == "schedule"
+    assert result.refresh_scope == frozenset({RefreshScope.STATUS})
 
 
 @pytest.mark.usefixtures("async_home")
@@ -643,10 +673,14 @@ async def test_process_webhook_light_mode_no_floodlight_attr(async_account):
 
     assert result.kind is WebhookKind.STATE
     assert result.touched_ids == []
+    # The module resolved fine, it just doesn't support floodlight -- not a
+    # stale topology, so no TOPOLOGY refresh.
+    assert result.refresh_scope == frozenset()
 
 
 @pytest.mark.usefixtures("async_home")
 async def test_process_webhook_light_mode_unresolvable_camera(async_account):
+    """A camera id that isn't in the home self-heals with TOPOLOGY (S4)."""
     home_id = "91763b24c43d3e344f424e8b"
     camera_id = "99:99:99:99:99:99"
 
@@ -662,10 +696,12 @@ async def test_process_webhook_light_mode_unresolvable_camera(async_account):
 
     assert result.kind is WebhookKind.STATE
     assert result.touched_ids == []
+    assert result.refresh_scope == frozenset({RefreshScope.TOPOLOGY})
 
 
 @pytest.mark.usefixtures("async_home")
 async def test_process_webhook_camera_on_unresolvable_camera(async_account):
+    """A camera id that isn't in the home self-heals with TOPOLOGY (S4)."""
     home_id = "91763b24c43d3e344f424e8b"
     camera_id = "99:99:99:99:99:99"
 
@@ -680,6 +716,7 @@ async def test_process_webhook_camera_on_unresolvable_camera(async_account):
 
     assert result.kind is WebhookKind.STATE
     assert result.touched_ids == []
+    assert result.refresh_scope == frozenset({RefreshScope.TOPOLOGY})
 
 
 @pytest.mark.usefixtures("async_home")
@@ -698,6 +735,7 @@ async def test_process_webhook_camera_off_unresolvable_camera(async_account):
 
     assert result.kind is WebhookKind.STATE
     assert result.touched_ids == []
+    assert result.refresh_scope == frozenset({RefreshScope.TOPOLOGY})
 
 
 @pytest.mark.usefixtures("async_home")
@@ -715,6 +753,9 @@ async def test_process_webhook_camera_monitoring_without_camera_id(
 
     assert result.kind is WebhookKind.STATE
     assert result.touched_ids == []
+    # No camera_id/device_id at all -- nothing was referenced, so nothing to
+    # self-heal.
+    assert result.refresh_scope == frozenset()
 
 
 @pytest.mark.usefixtures("async_home")
@@ -729,6 +770,7 @@ async def test_process_webhook_light_mode_without_camera_id(async_account):
 
     assert result.kind is WebhookKind.STATE
     assert result.touched_ids == []
+    assert result.refresh_scope == frozenset()
 
 
 @pytest.mark.usefixtures("async_home")
@@ -780,7 +822,9 @@ async def test_process_webhook_schedule_needs_refresh(async_account):
     result = await process_webhook(async_account, payload)
     assert result.kind is WebhookKind.TOPOLOGY_DIRTY
     assert result.needs_refresh is True
-    assert result.refresh_scope is RefreshScope.TOPOLOGY
+    assert result.refresh_scope == frozenset(
+        {RefreshScope.TOPOLOGY, RefreshScope.STATUS}
+    )
     assert result.touched_ids == []
 
 
@@ -861,7 +905,7 @@ async def test_process_webhook_topology_changed_variants(
 
     assert result.kind is WebhookKind.TOPOLOGY_DIRTY
     assert result.needs_refresh is True
-    assert result.refresh_scope is RefreshScope.TOPOLOGY
+    assert result.refresh_scope == frozenset({RefreshScope.TOPOLOGY})
     assert result.event_type == expected_change
     assert result.touched_ids == expected_touched
     assert result.events == []
@@ -1089,6 +1133,9 @@ async def test_process_webhook_non_str_sub_type_keeps_model_clean(async_account)
 
     assert result.touched_ids == []
     assert camera.floodlight == "auto"
+    # The camera resolved fine, only its sub_type was malformed -- not a
+    # stale topology, so no TOPOLOGY refresh.
+    assert result.refresh_scope == frozenset()
 
 
 @pytest.mark.usefixtures("async_home")
@@ -1109,6 +1156,8 @@ async def test_process_webhook_non_str_therm_mode_keeps_model_clean(async_accoun
 
     assert result.touched_ids == []
     assert home.therm_mode == "schedule"
+    # home is known, so therm_mode always resolves to a status poll (S1).
+    assert result.refresh_scope == frozenset({RefreshScope.STATUS})
 
 
 async def test_process_webhook_person_ids_are_strings(async_account):
@@ -1263,6 +1312,9 @@ async def test_process_webhook_set_point_without_setpoint_keys_reports_nothing(
     )
 
     assert result.touched_ids == []
+    # The room resolved fine, it just had nothing to merge -- not a stale
+    # topology, so no TOPOLOGY refresh.
+    assert result.refresh_scope == frozenset()
 
 
 def test_room_setpoint_keys_match_room_annotations():
@@ -1337,6 +1389,61 @@ async def test_process_webhook_device_event_modules_merges_dimmer(async_account)
     assert len(result.events) == 1
     assert result.events[0].event_type is None
     assert result.events[0].module_id == module_id
+    # Every module in the payload was merged -- no self-heal needed.
+    assert result.refresh_scope == frozenset()
+
+
+@pytest.mark.usefixtures("async_home")
+async def test_process_webhook_device_event_modules_unknown_module_self_heals(
+    async_account,
+):
+    """A module id that isn't in the home self-heals with TOPOLOGY (S4)."""
+    home_id = "91763b24c43d3e344f424e8b"
+
+    payload = {
+        "extra_params": {
+            "modules": [{"id": "does-not-exist", "on": True}],
+        },
+        "push_type": "device_event",
+        "device_id": "12:34:56:3c:63:b2",
+        "home_id": home_id,
+    }
+    result = await process_webhook(async_account, payload)
+
+    assert result.kind is WebhookKind.STATE
+    assert result.touched_ids == []
+    assert result.refresh_scope == frozenset({RefreshScope.TOPOLOGY})
+
+
+@pytest.mark.usefixtures("async_home")
+async def test_process_webhook_device_event_modules_mixed_known_and_unknown(
+    async_account,
+):
+    """One known module merges; one unknown id still self-heals with TOPOLOGY."""
+    home_id = "91763b24c43d3e344f424e8b"
+    module_id = "00:11:22:33:00:11:45:fe"
+    dimmer = async_account.homes[home_id].modules[module_id]
+    assert dimmer.on is False
+    assert dimmer.brightness == 63
+
+    payload = {
+        "extra_params": {
+            "modules": [
+                {"id": module_id, "on": True, "brightness": 33},
+                {"id": "does-not-exist", "on": True},
+            ],
+        },
+        "push_type": "device_event",
+        "device_id": "12:34:56:3c:63:b2",
+        "home_id": home_id,
+    }
+    result = await process_webhook(async_account, payload)
+
+    assert result.kind is WebhookKind.STATE
+    assert result.touched_ids == [module_id]
+    assert dimmer.on is True
+    assert dimmer.brightness == 33
+    assert result.refresh_scope == frozenset({RefreshScope.TOPOLOGY})
 
 
 @pytest.mark.usefixtures("async_home")
@@ -1410,6 +1517,9 @@ async def test_process_webhook_device_event_modules_skips_camera(async_account):
 
     assert result.kind is WebhookKind.STATE
     assert result.touched_ids == []
+    # The camera is present in the home, just deliberately skipped -- not a
+    # missing entity, so no topology self-heal.
+    assert result.refresh_scope == frozenset()
 
 
 @pytest.mark.usefixtures("async_home")
@@ -1450,6 +1560,7 @@ async def test_process_webhook_device_event_setpoint_event_merges_measured_tempe
     assert len(result.events) == 1
     assert result.events[0].event_type == "setpoint_event"
     assert result.events[0].mode == "home"
+    assert result.refresh_scope == frozenset()
 
 
 async def test_process_webhook_device_event_unknown_home_no_mutation(async_account):
@@ -1465,6 +1576,7 @@ async def test_process_webhook_device_event_unknown_home_no_mutation(async_accou
 
     assert result.kind is WebhookKind.STATE
     assert result.touched_ids == []
+    assert result.refresh_scope == frozenset({RefreshScope.TOPOLOGY})
 
 
 async def test_process_webhook_device_event_empty_extra_params(async_account):
@@ -1476,6 +1588,7 @@ async def test_process_webhook_device_event_empty_extra_params(async_account):
     result = await process_webhook(async_account, payload)
 
     assert result.kind is WebhookKind.UNKNOWN
+    assert result.refresh_scope == frozenset()
 
 
 @pytest.mark.usefixtures("async_home")
@@ -1509,6 +1622,7 @@ async def test_process_webhook_device_event_temperature_variation_merges_room(
     assert len(result.events) == 1
     assert result.events[0].event_type == "temperature_variation_event"
     assert result.events[0].mode == "home"
+    assert result.refresh_scope == frozenset()
 
 
 @pytest.mark.usefixtures("async_home")
@@ -1542,6 +1656,33 @@ async def test_process_webhook_device_event_motor_data_event_merges_position(
     assert len(result.events) == 1
     assert result.events[0].event_type == "motor_data_event"
     assert result.events[0].module_id == module_id
+    assert result.refresh_scope == frozenset()
+
+
+@pytest.mark.usefixtures("async_home")
+async def test_process_webhook_device_event_temperature_variation_unknown_room(
+    async_account,
+):
+    """A room_id that isn't in the home self-heals with TOPOLOGY (S4)."""
+    payload = {
+        "extra_params": {
+            "device_type": "NAPlug",
+            "event_type": "temperature_variation_event",
+            "mode": "home",
+            "room_id": "does-not-exist",
+            "setpoint": 19,
+            "temperature": 23.5,
+            "ts": 1786426877,
+        },
+        "push_type": "device_event",
+        "device_id": "12:34:56:00:bc:24",
+        "home_id": "91763b24c43d3e344f424e8b",
+    }
+    result = await process_webhook(async_account, payload)
+
+    assert result.kind is WebhookKind.STATE
+    assert result.touched_ids == []
+    assert result.refresh_scope == frozenset({RefreshScope.TOPOLOGY})
 
 
 async def test_process_webhook_device_event_motor_data_event_unknown_module(
@@ -1568,6 +1709,7 @@ async def test_process_webhook_device_event_motor_data_event_unknown_module(
     assert len(result.events) == 1
     assert result.events[0].event_type == "motor_data_event"
     assert result.events[0].module_id == "does-not-exist"
+    assert result.refresh_scope == frozenset({RefreshScope.TOPOLOGY})
 
 
 @pytest.mark.usefixtures("async_home")
@@ -1606,6 +1748,8 @@ async def test_process_webhook_device_event_boiler_event_surfaces_status(
     assert natherm1.boiler_status == natherm1_before
     assert oth.boiler_status == oth_before
     assert result.touched_ids == ["12:34:56:00:bc:24"]
+    # Ambiguous skip is expected, not a missing entity -- never self-heals.
+    assert result.refresh_scope == frozenset()
 
 
 async def test_process_webhook_device_event_boiler_off_maps_false(async_account):

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -1,0 +1,958 @@
+"""Tests for webhook payload processing."""
+
+from __future__ import annotations
+
+import pytest
+
+import pyatmo
+from pyatmo.helpers import number_or_none, str_or_none
+from pyatmo.room import Room
+from pyatmo.webhook import (
+    _ROOM_SETPOINT_KEYS,
+    LifecycleStatus,
+    WebhookEvent,
+    WebhookKind,
+    WebhookResult,
+    build_webhook_event,
+    classify,
+    process_webhook,
+    resolve_home_id,
+)
+
+
+def test_webhook_result_defaults():
+    result = WebhookResult(
+        home_id="h1",
+        event_type="set_point",
+        push_type="display_change",
+        kind=WebhookKind.STATE,
+    )
+    assert result.touched_ids == []
+    assert result.events == []
+    assert result.needs_refresh is False
+    assert result.lifecycle is None
+
+
+def test_webhook_event_defaults():
+    event = WebhookEvent(event_type="person", push_type="NACamera-person", home_id="h1")
+    assert event.person_ids == []
+    assert event.raw == {}
+    assert event.camera_id is None
+
+
+def test_webhook_types_exported_from_package():
+    assert pyatmo.WebhookResult is WebhookResult
+    assert pyatmo.WebhookKind is WebhookKind
+    assert pyatmo.WebhookEvent is WebhookEvent
+    assert pyatmo.LifecycleStatus is LifecycleStatus
+
+
+@pytest.mark.parametrize(
+    ("event_type", "push_type", "expected"),
+    [
+        ("set_point", "display_change", WebhookKind.STATE),
+        ("cancel_set_point", "display_change", WebhookKind.STATE),
+        ("therm_mode", "home_event_changed", WebhookKind.STATE),
+        ("on", "NACamera-on", WebhookKind.STATE),
+        ("off", "NACamera-off", WebhookKind.STATE),
+        ("light_mode", "NOC-light_mode", WebhookKind.STATE),
+        ("schedule", "home_event_changed", WebhookKind.TOPOLOGY_DIRTY),
+        ("person", "NACamera-person", WebhookKind.EVENT),
+        ("movement", "NACamera-movement", WebhookKind.EVENT),
+        ("disconnection", "NACamera-disconnection", WebhookKind.EVENT),
+        (None, "webhook_activation", WebhookKind.LIFECYCLE),
+        (None, "webhook_deactivation", WebhookKind.LIFECYCLE),
+        ("connection", "NACamera-connection", WebhookKind.LIFECYCLE),
+        ("something_new", "brand_new_push", WebhookKind.UNKNOWN),
+    ],
+)
+def test_classify(event_type, push_type, expected):
+    assert classify(event_type, push_type) is expected
+
+
+def test_resolve_home_id_top_level():
+    assert resolve_home_id({"home_id": "top"}) == "top"
+
+
+def test_resolve_home_id_nested():
+    assert resolve_home_id({"home": {"id": "nested"}}) == "nested"
+
+
+def test_resolve_home_id_top_level_wins_over_nested():
+    assert resolve_home_id({"home_id": "top", "home": {"id": "nested"}}) == "top"
+
+
+def test_resolve_home_id_missing():
+    assert resolve_home_id({"event_type": "on"}) is None
+
+
+def test_build_webhook_event_person():
+    payload = {
+        "persons": [
+            {"id": "p1", "is_known": True},
+            {"id": "p2", "is_known": False},
+        ],
+        "snapshot_url": "https://example/snap",
+        "event_type": "person",
+        "camera_id": "cam1",
+        "device_id": "cam1",
+        "home_id": "h1",
+        "message": "seen",
+        "push_type": "NACamera-person",
+    }
+    event = build_webhook_event(payload)
+    assert event.event_type == "person"
+    assert event.push_type == "NACamera-person"
+    assert event.home_id == "h1"
+    assert event.camera_id == "cam1"
+    assert event.person_ids == ["p1", "p2"]
+    assert event.snapshot_url == "https://example/snap"
+    assert event.message == "seen"
+    assert event.raw is payload
+
+
+async def test_process_webhook_activation(async_account):
+    result = await process_webhook(async_account, {"push_type": "webhook_activation"})
+    assert result.kind is WebhookKind.LIFECYCLE
+    assert result.lifecycle is LifecycleStatus.ACTIVATION
+    assert result.needs_refresh is False
+
+
+async def test_process_webhook_deactivation(async_account):
+    result = await process_webhook(
+        async_account,
+        {"push_type": "webhook_deactivation"},
+    )
+    assert result.kind is WebhookKind.LIFECYCLE
+    assert result.lifecycle is LifecycleStatus.DEACTIVATION
+
+
+async def test_process_webhook_camera_connection_needs_refresh(async_account):
+    result = await process_webhook(
+        async_account,
+        {"push_type": "NACamera-connection"},
+    )
+    assert result.kind is WebhookKind.LIFECYCLE
+    assert result.lifecycle is LifecycleStatus.CONNECTION
+    assert result.needs_refresh is True
+
+
+async def test_process_webhook_unknown(async_account):
+    result = await process_webhook(
+        async_account,
+        {"event_type": "brand_new", "push_type": "brand_new_push"},
+    )
+    assert result.kind is WebhookKind.UNKNOWN
+    assert result.touched_ids == []
+
+
+async def test_process_webhook_malformed_no_event(async_account):
+    result = await process_webhook(async_account, {})
+    assert result.kind is WebhookKind.UNKNOWN
+
+
+async def test_process_webhook_person_event(async_account):
+    payload = {
+        "persons": [{"id": "91827374-7e04-5298-83ad-a0cb8372dff1", "is_known": True}],
+        "snapshot_url": "https://example/snap",
+        "event_type": "person",
+        "camera_id": "12:34:56:00:f1:62",
+        "device_id": "12:34:56:00:f1:62",
+        "home_id": "91763b24c43d3e344f424e8b",
+        "message": "MYHOME: John Doe has been seen",
+        "push_type": "NACamera-person",
+    }
+    result = await process_webhook(async_account, payload)
+    assert result.kind is WebhookKind.EVENT
+    assert result.touched_ids == ["12:34:56:00:f1:62"]
+    assert len(result.events) == 1
+    event = result.events[0]
+    assert event.event_type == "person"
+    assert event.person_ids == ["91827374-7e04-5298-83ad-a0cb8372dff1"]
+
+
+async def test_process_webhook_movement_event(async_account):
+    payload = {
+        "event_type": "movement",
+        "device_id": "12:34:56:00:f1:62",
+        "camera_id": "12:34:56:00:f1:62",
+        "home_id": "91763b24c43d3e344f424e8b",
+        "push_type": "NACamera-movement",
+    }
+    result = await process_webhook(async_account, payload)
+    assert result.kind is WebhookKind.EVENT
+    assert result.events[0].event_type == "movement"
+    assert result.touched_ids == ["12:34:56:00:f1:62"]
+
+
+@pytest.mark.usefixtures("async_home")
+async def test_process_webhook_set_point_updates_room(async_account):
+    # async_home loads status for this home; async_account is its parent.
+    home_id = "91763b24c43d3e344f424e8b"
+    room = async_account.homes[home_id].rooms["2746182631"]
+    assert room.therm_setpoint_mode == "away"  # precondition from fixture
+    assert room.therm_measured_temperature == 19.8  # precondition from fixture
+    assert room.reachable is True  # precondition from fixture
+
+    payload = {
+        "room_id": "2746182631",
+        "home": {
+            "id": home_id,
+            "name": "MYHOME",
+            "rooms": [
+                {
+                    "id": "2746182631",
+                    "name": "Livingroom",
+                    "type": "livingroom",
+                    "therm_setpoint_mode": "manual",
+                    "therm_setpoint_temperature": 21,
+                    "therm_setpoint_end_time": 1612734552,
+                },
+            ],
+            "modules": [
+                {"id": "12:34:56:00:01:ae", "name": "Livingroom", "type": "NATherm1"},
+            ],
+        },
+        "mode": "manual",
+        "event_type": "set_point",
+        "temperature": 21,
+        "push_type": "display_change",
+    }
+    result = await process_webhook(async_account, payload)
+
+    assert result.kind is WebhookKind.STATE
+    assert result.touched_ids == ["2746182631"]
+    assert room.therm_setpoint_mode == "manual"
+    assert room.therm_setpoint_temperature == 21
+    # Telemetry not present in the webhook payload must be preserved, not wiped.
+    assert room.therm_measured_temperature == 19.8
+    assert room.reachable is True
+
+
+@pytest.mark.usefixtures("async_home")
+async def test_process_webhook_set_point_partial_room_match(async_account):
+    home_id = "91763b24c43d3e344f424e8b"
+    room = async_account.homes[home_id].rooms["2746182631"]
+
+    payload = {
+        "event_type": "set_point",
+        "home": {
+            "id": home_id,
+            "rooms": [
+                {"id": "2746182631", "therm_setpoint_mode": "manual"},
+                {"id": "does-not-exist", "therm_setpoint_mode": "max"},
+            ],
+        },
+        "push_type": "display_change",
+    }
+    result = await process_webhook(async_account, payload)
+
+    assert result.kind is WebhookKind.STATE
+    assert result.touched_ids == ["2746182631"]
+    assert room.therm_setpoint_mode == "manual"
+
+
+@pytest.mark.usefixtures("async_home")
+@pytest.mark.parametrize("home_block", [None, "x"])
+async def test_process_webhook_set_point_without_usable_home_block(
+    async_account,
+    home_block,
+):
+    payload = {
+        "event_type": "set_point",
+        "home_id": "91763b24c43d3e344f424e8b",
+        "push_type": "display_change",
+    }
+    if home_block is not None:
+        payload["home"] = home_block
+
+    result = await process_webhook(async_account, payload)
+
+    assert result.kind is WebhookKind.STATE
+    assert result.touched_ids == []
+
+
+async def test_process_webhook_set_point_unknown_home_no_mutation(async_account):
+    payload = {
+        "home": {"id": "does-not-exist", "rooms": [{"id": "r1"}], "modules": []},
+        "event_type": "set_point",
+        "push_type": "display_change",
+    }
+    result = await process_webhook(async_account, payload)
+    assert result.kind is WebhookKind.STATE
+    assert result.touched_ids == []
+
+
+@pytest.mark.usefixtures("async_home")
+async def test_process_webhook_therm_mode_updates_home(async_account):
+    home_id = "91763b24c43d3e344f424e8b"
+    home = async_account.homes[home_id]
+    assert home.therm_mode == "schedule"  # precondition from fixture
+
+    payload = {
+        "event_type": "therm_mode",
+        "home": {"id": home_id, "therm_mode": "hg"},
+        "mode": "hg",
+        "previous_mode": "schedule",
+        "push_type": "home_event_changed",
+    }
+    result = await process_webhook(async_account, payload)
+
+    assert result.kind is WebhookKind.STATE
+    assert result.touched_ids == [home_id]
+    assert home.therm_mode == "hg"
+
+
+@pytest.mark.usefixtures("async_home")
+@pytest.mark.parametrize(
+    "home_block",
+    [None, "x", {"id": "91763b24c43d3e344f424e8b"}],
+)
+async def test_process_webhook_therm_mode_without_mode_touches_nothing(
+    async_account,
+    home_block,
+):
+    home_id = "91763b24c43d3e344f424e8b"
+    home = async_account.homes[home_id]
+    assert home.therm_mode == "schedule"  # precondition from fixture
+
+    payload = {
+        "event_type": "therm_mode",
+        "home_id": home_id,
+        "push_type": "home_event_changed",
+    }
+    if home_block is not None:
+        payload["home"] = home_block
+
+    result = await process_webhook(async_account, payload)
+
+    assert result.kind is WebhookKind.STATE
+    assert result.touched_ids == []
+    assert home.therm_mode == "schedule"
+
+
+@pytest.mark.usefixtures("async_home")
+async def test_process_webhook_camera_off(async_account):
+    home_id = "91763b24c43d3e344f424e8b"
+    camera_id = "12:34:56:00:f1:62"
+    camera = async_account.homes[home_id].modules[camera_id]
+    assert camera.monitoring is True  # precondition from fixture
+
+    payload = {
+        "event_type": "off",
+        "device_id": camera_id,
+        "camera_id": camera_id,
+        "home_id": home_id,
+        "push_type": "NACamera-off",
+    }
+    result = await process_webhook(async_account, payload)
+
+    assert result.kind is WebhookKind.STATE
+    assert result.touched_ids == [camera_id]
+    assert camera.monitoring is False
+
+
+@pytest.mark.usefixtures("async_home")
+async def test_process_webhook_camera_on(async_account):
+    home_id = "91763b24c43d3e344f424e8b"
+    camera_id = "12:34:56:00:f1:62"
+    camera = async_account.homes[home_id].modules[camera_id]
+    camera.monitoring = False
+
+    payload = {
+        "event_type": "on",
+        "device_id": camera_id,
+        "camera_id": camera_id,
+        "home_id": home_id,
+        "push_type": "NACamera-on",
+    }
+    result = await process_webhook(async_account, payload)
+    assert camera.monitoring is True
+    assert result.touched_ids == [camera_id]
+
+
+@pytest.mark.usefixtures("async_home")
+async def test_process_webhook_light_mode(async_account):
+    home_id = "91763b24c43d3e344f424e8b"
+    camera_id = "12:34:56:10:b9:0e"  # NOC, has floodlight attr
+    camera = async_account.homes[home_id].modules[camera_id]
+
+    payload = {
+        "event_type": "light_mode",
+        "device_id": camera_id,
+        "camera_id": camera_id,
+        "home_id": home_id,
+        "push_type": "NOC-light_mode",
+        "sub_type": "on",
+    }
+    result = await process_webhook(async_account, payload)
+
+    assert result.kind is WebhookKind.STATE
+    assert result.touched_ids == [camera_id]
+    assert camera.floodlight == "on"
+
+
+@pytest.mark.usefixtures("async_home")
+async def test_process_webhook_light_mode_no_floodlight_attr(async_account):
+    home_id = "91763b24c43d3e344f424e8b"
+    camera_id = "12:34:56:00:01:ae"  # NATherm1, has no floodlight attr
+
+    payload = {
+        "event_type": "light_mode",
+        "device_id": camera_id,
+        "camera_id": camera_id,
+        "home_id": home_id,
+        "push_type": "NOC-light_mode",
+        "sub_type": "on",
+    }
+    result = await process_webhook(async_account, payload)
+
+    assert result.kind is WebhookKind.STATE
+    assert result.touched_ids == []
+
+
+@pytest.mark.usefixtures("async_home")
+async def test_process_webhook_light_mode_unresolvable_camera(async_account):
+    home_id = "91763b24c43d3e344f424e8b"
+    camera_id = "99:99:99:99:99:99"
+
+    payload = {
+        "event_type": "light_mode",
+        "device_id": camera_id,
+        "camera_id": camera_id,
+        "home_id": home_id,
+        "push_type": "NOC-light_mode",
+        "sub_type": "on",
+    }
+    result = await process_webhook(async_account, payload)
+
+    assert result.kind is WebhookKind.STATE
+    assert result.touched_ids == []
+
+
+@pytest.mark.usefixtures("async_home")
+async def test_process_webhook_camera_on_unresolvable_camera(async_account):
+    home_id = "91763b24c43d3e344f424e8b"
+    camera_id = "99:99:99:99:99:99"
+
+    payload = {
+        "event_type": "on",
+        "device_id": camera_id,
+        "camera_id": camera_id,
+        "home_id": home_id,
+        "push_type": "NACamera-on",
+    }
+    result = await process_webhook(async_account, payload)
+
+    assert result.kind is WebhookKind.STATE
+    assert result.touched_ids == []
+
+
+@pytest.mark.usefixtures("async_home")
+async def test_process_webhook_camera_off_unresolvable_camera(async_account):
+    home_id = "91763b24c43d3e344f424e8b"
+    camera_id = "99:99:99:99:99:99"
+
+    payload = {
+        "event_type": "off",
+        "device_id": camera_id,
+        "camera_id": camera_id,
+        "home_id": home_id,
+        "push_type": "NACamera-off",
+    }
+    result = await process_webhook(async_account, payload)
+
+    assert result.kind is WebhookKind.STATE
+    assert result.touched_ids == []
+
+
+@pytest.mark.usefixtures("async_home")
+@pytest.mark.parametrize("event_type", ["on", "off"])
+async def test_process_webhook_camera_monitoring_without_camera_id(
+    async_account,
+    event_type,
+):
+    payload = {
+        "event_type": event_type,
+        "home_id": "91763b24c43d3e344f424e8b",
+        "push_type": f"NACamera-{event_type}",
+    }
+    result = await process_webhook(async_account, payload)
+
+    assert result.kind is WebhookKind.STATE
+    assert result.touched_ids == []
+
+
+@pytest.mark.usefixtures("async_home")
+async def test_process_webhook_light_mode_without_camera_id(async_account):
+    payload = {
+        "event_type": "light_mode",
+        "home_id": "91763b24c43d3e344f424e8b",
+        "push_type": "NOC-light_mode",
+        "sub_type": "on",
+    }
+    result = await process_webhook(async_account, payload)
+
+    assert result.kind is WebhookKind.STATE
+    assert result.touched_ids == []
+
+
+@pytest.mark.usefixtures("async_home")
+@pytest.mark.parametrize("sub_type_block", [{}, {"sub_type": None}])
+async def test_process_webhook_light_mode_without_sub_type_keeps_value(
+    async_account,
+    sub_type_block,
+):
+    home_id = "91763b24c43d3e344f424e8b"
+    camera_id = "12:34:56:10:b9:0e"  # NOC, has floodlight attr
+    camera = async_account.homes[home_id].modules[camera_id]
+    assert camera.floodlight == "auto"  # precondition from fixture
+
+    payload = {
+        "event_type": "light_mode",
+        "device_id": camera_id,
+        "camera_id": camera_id,
+        "home_id": home_id,
+        "push_type": "NOC-light_mode",
+    }
+    payload.update(sub_type_block)
+
+    result = await process_webhook(async_account, payload)
+
+    assert result.kind is WebhookKind.STATE
+    assert result.touched_ids == []
+    assert camera.floodlight == "auto"
+
+
+async def test_process_webhook_malformed_non_dict_home_no_raise(async_account):
+    payload = {
+        "event_type": "on",
+        "home": "x",
+        "push_type": "NACamera-on",
+    }
+    result = await process_webhook(async_account, payload)
+
+    assert result.kind is WebhookKind.STATE
+    assert result.touched_ids == []
+
+
+async def test_process_webhook_schedule_needs_refresh(async_account):
+    payload = {
+        "event_type": "schedule",
+        "schedule_id": "b1b54a2f45795764f59d50d8",
+        "home_id": "91763b24c43d3e344f424e8b",
+        "push_type": "home_event_changed",
+    }
+    result = await process_webhook(async_account, payload)
+    assert result.kind is WebhookKind.TOPOLOGY_DIRTY
+    assert result.needs_refresh is True
+    assert result.touched_ids == []
+
+
+async def test_account_process_webhook_delegates(async_account):
+    result = await async_account.process_webhook({"push_type": "webhook_activation"})
+    assert result.kind is WebhookKind.LIFECYCLE
+    assert result.lifecycle is LifecycleStatus.ACTIVATION
+
+
+@pytest.mark.parametrize(
+    "event_type",
+    [
+        "hush",
+        "smoke",
+        "co_detected",
+        "tampered",
+        "detection_chamber_status",
+        "sound_test",
+        "siren_sounding",
+        "siren_tampered",
+        "incoming_call",
+        "accepted_call",
+        "missed_call",
+        "sd",
+        "alim",
+        "boot",
+        "new_module",
+        "module_low_battery",
+        "module_end_update",
+        "tag_uninstalled",
+        "daily_summary",
+        "human",
+        "animal",
+        "vehicle",
+        "alarm_started",
+    ],
+)
+def test_classify_full_event_stream_catalog(event_type):
+    # Smoke/siren/doorbell/tag/health/module events surface as EVENT, not UNKNOWN.
+    assert classify(event_type, f"NSD-{event_type}") is WebhookKind.EVENT
+
+
+@pytest.mark.parametrize("event_type", ["on", "off"])
+def test_classify_on_off_stay_state(event_type):
+    # on/off are in the EventTypes enum but must remain STATE, not EVENT.
+    assert classify(event_type, f"NACamera-{event_type}") is WebhookKind.STATE
+
+
+@pytest.mark.parametrize(
+    "persons",
+    [None, "abc", ["x"], [1, 2], {"id": "p1"}],
+)
+async def test_process_webhook_malformed_persons_no_raise(async_account, persons):
+    payload = {
+        "event_type": "person",
+        "home_id": "91763b24c43d3e344f424e8b",
+        "push_type": "NACamera-person",
+        "persons": persons,
+    }
+    result = await process_webhook(async_account, payload)
+
+    assert result.kind is WebhookKind.EVENT
+    assert result.touched_ids == []
+    assert result.events[0].person_ids == []
+
+
+@pytest.mark.parametrize("rooms", [None, ["x"]])
+async def test_process_webhook_malformed_rooms_no_raise(async_account, rooms):
+    payload = {
+        "event_type": "set_point",
+        "home": {"id": "91763b24c43d3e344f424e8b", "rooms": rooms},
+        "push_type": "display_change",
+    }
+    result = await process_webhook(async_account, payload)
+
+    assert result.kind is WebhookKind.STATE
+    assert result.touched_ids == []
+
+
+async def test_process_webhook_event_touched_ids_from_module_id(async_account):
+    payload = {
+        "event_type": "module_low_battery",
+        "module_id": "12:34:56:00:01:ae",
+        "home_id": "91763b24c43d3e344f424e8b",
+        "push_type": "NATherm1-module_low_battery",
+    }
+    result = await process_webhook(async_account, payload)
+
+    assert result.kind is WebhookKind.EVENT
+    assert result.touched_ids == ["12:34:56:00:01:ae"]
+    assert result.events[0].module_id == "12:34:56:00:01:ae"
+
+
+async def test_process_webhook_event_touched_ids_are_strings(async_account):
+    payload = {
+        "event_type": "movement",
+        "device_id": {"a": 1},
+        "camera_id": "12:34:56:00:f1:62",
+        "home_id": "91763b24c43d3e344f424e8b",
+        "push_type": "NACamera-movement",
+    }
+    result = await process_webhook(async_account, payload)
+
+    assert result.kind is WebhookKind.EVENT
+    assert all(isinstance(touched_id, str) for touched_id in result.touched_ids)
+    assert result.touched_ids == ["12:34:56:00:f1:62"]
+
+
+async def test_process_webhook_smoke_event_surfaced(async_account):
+    payload = {
+        "event_type": "smoke",
+        "device_id": "12:34:56:00:e3:9b",
+        "home_id": "91763b24c43d3e344f424e8b",
+        "push_type": "NSD-smoke",
+    }
+    result = await process_webhook(async_account, payload)
+    assert result.kind is WebhookKind.EVENT
+    assert result.events[0].event_type == "smoke"
+    assert result.touched_ids == ["12:34:56:00:e3:9b"]
+
+
+@pytest.mark.usefixtures("async_home")
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"event_type": ["on"], "push_type": "NACamera-on"},
+        {"event_type": "movement", "push_type": ["x"]},
+        {"event_type": "set_point", "push_type": "display_change", "home_id": {"a": 1}},
+        {
+            "event_type": "set_point",
+            "push_type": "display_change",
+            "home": {"id": ["x"]},
+        },
+        {
+            "event_type": "set_point",
+            "push_type": "display_change",
+            "home": {
+                "id": "91763b24c43d3e344f424e8b",
+                "rooms": [{"id": ["2746182631"], "therm_setpoint_mode": "manual"}],
+            },
+        },
+        {
+            "event_type": "on",
+            "push_type": "NACamera-on",
+            "home_id": "91763b24c43d3e344f424e8b",
+            "camera_id": {"a": 1},
+        },
+        {
+            "event_type": "off",
+            "push_type": "NACamera-off",
+            "home_id": "91763b24c43d3e344f424e8b",
+            "device_id": ["x"],
+        },
+        {
+            "event_type": "light_mode",
+            "push_type": "NOC-light_mode",
+            "home_id": "91763b24c43d3e344f424e8b",
+            "camera_id": {"a": 1},
+            "sub_type": "on",
+        },
+    ],
+)
+async def test_process_webhook_unhashable_scalar_no_raise(async_account, payload):
+    """An unhashable value in any looked-up field must not raise."""
+    result = await process_webhook(async_account, payload)
+
+    assert result.touched_ids == []
+
+
+@pytest.mark.usefixtures("async_home")
+async def test_process_webhook_non_str_sub_type_keeps_model_clean(async_account):
+    """A malformed sub_type must not land on the module's floodlight attribute."""
+    home_id = "91763b24c43d3e344f424e8b"
+    camera_id = "12:34:56:10:b9:0e"  # NOC, has floodlight attr
+    camera = async_account.homes[home_id].modules[camera_id]
+    assert camera.floodlight == "auto"  # precondition from fixture
+
+    result = await process_webhook(
+        async_account,
+        {
+            "event_type": "light_mode",
+            "push_type": "NOC-light_mode",
+            "home_id": home_id,
+            "camera_id": camera_id,
+            "sub_type": {"evil": 1},
+        },
+    )
+
+    assert result.touched_ids == []
+    assert camera.floodlight == "auto"
+
+
+@pytest.mark.usefixtures("async_home")
+async def test_process_webhook_non_str_therm_mode_keeps_model_clean(async_account):
+    """A malformed therm_mode must not land on the home's therm_mode attribute."""
+    home_id = "91763b24c43d3e344f424e8b"
+    home = async_account.homes[home_id]
+    assert home.therm_mode == "schedule"  # precondition from fixture
+
+    result = await process_webhook(
+        async_account,
+        {
+            "event_type": "therm_mode",
+            "push_type": "home_event_changed",
+            "home": {"id": home_id, "therm_mode": [1, 2]},
+        },
+    )
+
+    assert result.touched_ids == []
+    assert home.therm_mode == "schedule"
+
+
+async def test_process_webhook_person_ids_are_strings(async_account):
+    """Non-string person ids are dropped, matching the touched_ids guard."""
+    result = await process_webhook(
+        async_account,
+        {
+            "event_type": "person",
+            "push_type": "NACamera-person",
+            "home_id": "91763b24c43d3e344f424e8b",
+            "persons": [{"id": 7}, {"id": None}, "junk", {"id": "p1"}],
+        },
+    )
+
+    assert result.events[0].person_ids == ["p1"]
+
+
+async def test_process_webhook_event_id_fields_are_strings(async_account):
+    """A non-string id is dropped from the event too, not just from touched_ids."""
+    result = await process_webhook(
+        async_account,
+        {
+            "event_type": "movement",
+            "push_type": "NACamera-movement",
+            "home_id": "91763b24c43d3e344f424e8b",
+            "device_id": {"a": 1},
+            "camera_id": "12:34:56:00:f1:62",
+        },
+    )
+
+    assert result.events[0].device_id is None
+    assert result.events[0].camera_id == "12:34:56:00:f1:62"
+    assert result.touched_ids == ["12:34:56:00:f1:62"]
+
+
+@pytest.mark.usefixtures("async_home")
+async def test_process_webhook_set_point_rejects_wrongly_typed_values(async_account):
+    """A malformed setpoint value is dropped, preserving the known-good value."""
+    home_id = "91763b24c43d3e344f424e8b"
+    room = async_account.homes[home_id].rooms["2746182631"]
+    assert room.therm_setpoint_mode == "away"  # precondition from fixture
+    assert room.therm_setpoint_temperature == 12  # precondition from fixture
+
+    result = await process_webhook(
+        async_account,
+        {
+            "event_type": "set_point",
+            "push_type": "display_change",
+            "home": {
+                "id": home_id,
+                "rooms": [
+                    {
+                        "id": "2746182631",
+                        "therm_setpoint_mode": {"evil": 1},
+                        "therm_setpoint_temperature": "hot",
+                    },
+                ],
+            },
+        },
+    )
+
+    assert result.touched_ids == []
+    assert room.therm_setpoint_mode == "away"
+    assert room.therm_setpoint_temperature == 12
+
+
+@pytest.mark.usefixtures("async_home")
+async def test_process_webhook_set_point_does_not_alias_payload_values(async_account):
+    """A mutable payload value must never be stored on the model."""
+    home_id = "91763b24c43d3e344f424e8b"
+    room = async_account.homes[home_id].rooms["2746182631"]
+    shared = [1, 2]
+
+    await process_webhook(
+        async_account,
+        {
+            "event_type": "set_point",
+            "push_type": "display_change",
+            "home": {
+                "id": home_id,
+                "rooms": [{"id": "2746182631", "therm_setpoint_end_time": shared}],
+            },
+        },
+    )
+
+    assert room.therm_setpoint_end_time is not shared
+
+
+@pytest.mark.usefixtures("async_home")
+async def test_process_webhook_set_point_explicit_null_clears_value(async_account):
+    """An explicit `null` clears the field; only wrong types are rejected."""
+    home_id = "91763b24c43d3e344f424e8b"
+    room = async_account.homes[home_id].rooms["2746182631"]
+    assert room.therm_setpoint_mode == "away"  # precondition from fixture
+
+    result = await process_webhook(
+        async_account,
+        {
+            "event_type": "set_point",
+            "push_type": "display_change",
+            "home": {
+                "id": home_id,
+                "rooms": [{"id": "2746182631", "therm_setpoint_mode": None}],
+            },
+        },
+    )
+
+    assert result.touched_ids == ["2746182631"]
+    assert room.therm_setpoint_mode is None
+
+
+@pytest.mark.usefixtures("async_home")
+async def test_process_webhook_set_point_keeps_falsy_values(async_account):
+    """`0` is a valid setpoint value and must not be skipped as falsy."""
+    home_id = "91763b24c43d3e344f424e8b"
+    room = async_account.homes[home_id].rooms["2746182631"]
+
+    result = await process_webhook(
+        async_account,
+        {
+            "event_type": "set_point",
+            "push_type": "display_change",
+            "home": {
+                "id": home_id,
+                "rooms": [{"id": "2746182631", "therm_setpoint_temperature": 0}],
+            },
+        },
+    )
+
+    assert result.touched_ids == ["2746182631"]
+    assert room.therm_setpoint_temperature == 0
+
+
+@pytest.mark.usefixtures("async_home")
+async def test_process_webhook_set_point_without_setpoint_keys_reports_nothing(
+    async_account,
+):
+    """A resolved room carrying no setpoint keys is not reported as touched."""
+    home_id = "91763b24c43d3e344f424e8b"
+
+    result = await process_webhook(
+        async_account,
+        {
+            "event_type": "set_point",
+            "push_type": "display_change",
+            "home": {
+                "id": home_id,
+                "rooms": [{"id": "2746182631", "name": "Livingroom"}],
+            },
+        },
+    )
+
+    assert result.touched_ids == []
+
+
+def test_room_setpoint_keys_match_room_annotations():
+    """Every coercer matches the type `Room` declares for that field.
+
+    `_ROOM_SETPOINT_KEYS` duplicates type knowledge that already lives on
+    `Room`, so drift would silently reject a valid value rather than fail. This
+    pins the two together. Read `__annotations__` directly: `get_type_hints`
+    cannot resolve `Room`'s `TYPE_CHECKING`-only names.
+    """
+    coercer_for = {
+        "str|None": str_or_none,
+        "int|None": number_or_none,
+        "float|None": number_or_none,
+    }
+
+    for key, coerce in _ROOM_SETPOINT_KEYS.items():
+        declared = Room.__annotations__[key].replace(" ", "")
+        assert declared in coercer_for, f"{key}: unhandled declared type {declared!r}"
+        assert coerce is coercer_for[declared], (
+            f"{key}: Room declares {declared}, but the table coerces with "
+            f"{coerce.__name__}"
+        )
+
+
+async def test_process_webhook_never_suspends(async_account):
+    """`process_webhook` must run to completion without yielding to the loop.
+
+    Netatmo requires a webhook endpoint to answer immediately and deactivates
+    one that does not, so the merge deliberately performs no I/O. Awaiting
+    anything here -- an `async_update_*` refresh being the tempting one -- would
+    put network latency, including the 429 backoff in `auth.py`, on the response
+    path. Driving the coroutine one step must therefore finish it: a suspension
+    yields instead of raising `StopIteration`.
+    """
+    payload = {
+        "event_type": "movement",
+        "push_type": "NACamera-movement",
+        "home_id": "91763b24c43d3e344f424e8b",
+        "device_id": "12:34:56:00:f1:62",
+    }
+    coro = process_webhook(async_account, payload)
+    try:
+        with pytest.raises(StopIteration):
+            coro.send(None)
+    finally:
+        coro.close()

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -1661,6 +1661,60 @@ async def test_process_webhook_device_event_motor_data_event_merges_position(
 
 
 @pytest.mark.usefixtures("async_home")
+async def test_process_webhook_device_event_heating_power_request_merges_room(
+    async_account,
+):
+    """Real capture: heating demand % merges onto the room, drives HVAC action."""
+    home_id = "91763b24c43d3e344f424e8b"
+    room = async_account.homes[home_id].rooms["2940411577"]
+    assert room.heating_power_request == 0
+
+    payload = {
+        "extra_params": {
+            "device_type": "NAPlug",
+            "event_type": "heating_power_request_event",
+            "heating_power_request": 100,
+            "room_id": "2940411577",
+            "ts": 1786522899,
+        },
+        "push_type": "device_event",
+        "device_id": "12:34:56:00:bc:24",
+        "home_id": home_id,
+    }
+    result = await process_webhook(async_account, payload)
+
+    assert result.kind is WebhookKind.STATE
+    assert result.touched_ids == ["2940411577"]
+    assert room.heating_power_request == 100
+    assert len(result.events) == 1
+    assert result.events[0].event_type == "heating_power_request_event"
+    assert result.refresh_scope == frozenset()
+
+
+@pytest.mark.usefixtures("async_home")
+async def test_process_webhook_device_event_heating_power_request_unknown_room(
+    async_account,
+):
+    """An unknown room_id self-heals with TOPOLOGY."""
+    payload = {
+        "extra_params": {
+            "device_type": "NAPlug",
+            "event_type": "heating_power_request_event",
+            "heating_power_request": 100,
+            "room_id": "does-not-exist",
+            "ts": 1786522899,
+        },
+        "push_type": "device_event",
+        "device_id": "12:34:56:00:bc:24",
+        "home_id": "91763b24c43d3e344f424e8b",
+    }
+    result = await process_webhook(async_account, payload)
+
+    assert result.kind is WebhookKind.STATE
+    assert result.refresh_scope == frozenset({RefreshScope.TOPOLOGY})
+
+
+@pytest.mark.usefixtures("async_home")
 async def test_process_webhook_device_event_temperature_variation_unknown_room(
     async_account,
 ):

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -52,6 +52,7 @@ def test_webhook_types_exported_from_package():
     [
         ("set_point", "display_change", WebhookKind.STATE),
         ("cancel_set_point", "display_change", WebhookKind.STATE),
+        ("setpoint_event", "display_change", WebhookKind.STATE),
         ("therm_mode", "home_event_changed", WebhookKind.STATE),
         ("on", "NACamera-on", WebhookKind.STATE),
         ("off", "NACamera-off", WebhookKind.STATE),
@@ -227,6 +228,52 @@ async def test_process_webhook_set_point_updates_room(async_account):
     # Telemetry not present in the webhook payload must be preserved, not wiped.
     assert room.therm_measured_temperature == 19.8
     assert room.reachable is True
+
+
+@pytest.mark.usefixtures("async_home")
+async def test_process_webhook_setpoint_event_alias_merges_room(async_account):
+    """Real `display_change` payloads use `setpoint_event`, not `set_point`.
+
+    Redacted/remapped real capture: home/room ids point at the fixture home,
+    `user_id` dropped.
+    """
+    home_id = "91763b24c43d3e344f424e8b"
+    room = async_account.homes[home_id].rooms["2746182631"]
+    assert room.therm_setpoint_mode == "away"  # precondition from fixture
+    assert room.therm_setpoint_temperature == 12  # precondition from fixture
+    assert room.therm_measured_temperature == 19.8  # precondition from fixture
+
+    payload = {
+        "home": {
+            "id": home_id,
+            "rooms": [
+                {
+                    "id": "2746182631",
+                    "therm_setpoint_start_time": 1786428433,
+                    "therm_setpoint_mode": "manual",
+                    "therm_setpoint_end_time": 1786439233,
+                    "therm_setpoint_temperature": 13.5,
+                },
+            ],
+        },
+        "correlation_id": "3656857635745554143",
+        "type": "setpoint_event",
+        "home_id": home_id,
+        "device_id": "12:34:56:00:bc:24",
+        "event_type": "setpoint_event",
+        "room_id": "2746182631",
+        "mode": "manual",
+        "temperature": 13.5,
+        "push_type": "display_change",
+    }
+    result = await process_webhook(async_account, payload)
+
+    assert result.kind is WebhookKind.STATE
+    assert result.touched_ids == ["2746182631"]
+    assert room.therm_setpoint_mode == "manual"
+    assert room.therm_setpoint_temperature == 13.5
+    # Telemetry not present in the webhook payload must be preserved, not wiped.
+    assert room.therm_measured_temperature == 19.8
 
 
 @pytest.mark.usefixtures("async_home")
@@ -956,3 +1003,156 @@ async def test_process_webhook_never_suspends(async_account):
             coro.send(None)
     finally:
         coro.close()
+
+
+@pytest.mark.usefixtures("async_home")
+async def test_process_webhook_device_event_modules_merges_dimmer(async_account):
+    """The `device_event` envelope's `extra_params.modules[]` merges via Module.update.
+
+    Redacted/remapped real capture: dimmer id points at the fixture's NLF
+    module (fixture start: on=False, brightness=63).
+    """
+    home_id = "91763b24c43d3e344f424e8b"
+    module_id = "00:11:22:33:00:11:45:fe"
+    dimmer = async_account.homes[home_id].modules[module_id]
+    assert dimmer.on is False  # precondition from fixture
+    assert dimmer.brightness == 63  # precondition from fixture
+
+    payload = {
+        "extra_params": {
+            "correlation_id": 13915705160800893000,
+            "modules": [
+                {
+                    "brightness": 33,
+                    "on": True,
+                    "power": 0,
+                    "reachable": True,
+                    "room_id": "2313121935",
+                    "id": module_id,
+                    "type": "NLF",
+                },
+            ],
+            "sequence_id": 12675,
+            "source": "netcom",
+        },
+        "push_type": "device_event",
+        "device_id": "12:34:56:3c:63:b2",
+        "home_id": home_id,
+    }
+    result = await process_webhook(async_account, payload)
+
+    assert result.kind is WebhookKind.STATE
+    assert result.touched_ids == [module_id]
+    assert dimmer.on is True
+    assert dimmer.brightness == 33
+
+
+@pytest.mark.usefixtures("async_home")
+async def test_process_webhook_device_event_modules_skips_camera(async_account):
+    """A camera named in `extra_params.modules[]` must never be merged.
+
+    `Camera.update` performs network I/O (`async_update_camera_urls`), which
+    must never run on the webhook response path. Current real captures only
+    carry dimmers/switches, but this guards defensively against a future
+    payload naming a camera.
+    """
+    home_id = "91763b24c43d3e344f424e8b"
+    camera_id = "12:34:56:00:f1:62"  # NACamera, in fixture
+
+    payload = {
+        "extra_params": {
+            "modules": [{"id": camera_id, "type": "NACamera", "monitoring": "off"}],
+        },
+        "push_type": "device_event",
+        "device_id": "12:34:56:3c:63:b2",
+        "home_id": home_id,
+    }
+    result = await process_webhook(async_account, payload)
+
+    assert result.kind is WebhookKind.STATE
+    assert result.touched_ids == []
+
+
+@pytest.mark.usefixtures("async_home")
+async def test_process_webhook_device_event_energy_setpoint_no_merge(async_account):
+    """An `extra_params.event_type` energy event surfaces as EVENT, no merge.
+
+    Netatmo also sends the same change as a top-level `display_change`
+    payload, which is the authoritative, cleanly-keyed source for the room
+    merge; merging this differently-keyed variant too would double-apply.
+    """
+    home_id = "91763b24c43d3e344f424e8b"
+    room = async_account.homes[home_id].rooms["2746182631"]
+    assert room.therm_setpoint_mode == "away"  # precondition from fixture
+
+    payload = {
+        "extra_params": {
+            "device_type": "NAPlug",
+            "event_type": "setpoint_event",
+            "mode": "manual",
+            "room_id": "2746182631",
+            "temperature": 13.5,
+            "therm_measured_temperature": 23.3,
+            "ts": 1786428434,
+            "ts_begin": 1786428433,
+            "ts_end": 1786439233,
+        },
+        "push_type": "device_event",
+        "device_id": "12:34:56:00:bc:24",
+        "home_id": home_id,
+    }
+    result = await process_webhook(async_account, payload)
+
+    assert result.kind is WebhookKind.EVENT
+    assert result.events[0].event_type == "setpoint_event"
+    assert result.touched_ids == ["12:34:56:00:bc:24"]
+    # No speculative merge: the room's setpoint must be untouched by this path.
+    assert room.therm_setpoint_mode == "away"
+
+
+async def test_process_webhook_device_event_unknown_home_no_mutation(async_account):
+    payload = {
+        "extra_params": {
+            "modules": [{"id": "00:11:22:33:00:11:45:fe", "on": True}],
+        },
+        "push_type": "device_event",
+        "device_id": "12:34:56:3c:63:b2",
+        "home_id": "does-not-exist",
+    }
+    result = await process_webhook(async_account, payload)
+
+    assert result.kind is WebhookKind.STATE
+    assert result.touched_ids == []
+
+
+async def test_process_webhook_device_event_empty_extra_params(async_account):
+    payload = {
+        "extra_params": {},
+        "push_type": "device_event",
+        "home_id": "91763b24c43d3e344f424e8b",
+    }
+    result = await process_webhook(async_account, payload)
+
+    assert result.kind is WebhookKind.UNKNOWN
+
+
+async def test_process_webhook_device_event_temperature_variation(async_account):
+    """A second energy-event shape (`temperature_variation_event`) surfaces as EVENT."""
+    payload = {
+        "extra_params": {
+            "device_type": "NAPlug",
+            "event_type": "temperature_variation_event",
+            "mode": "home",
+            "room_id": "2746182631",
+            "setpoint": 19,
+            "temperature": 23.5,
+            "ts": 1786426877,
+        },
+        "push_type": "device_event",
+        "device_id": "12:34:56:00:bc:24",
+        "home_id": "91763b24c43d3e344f424e8b",
+    }
+    result = await process_webhook(async_account, payload)
+
+    assert result.kind is WebhookKind.EVENT
+    assert result.events[0].event_type == "temperature_variation_event"

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -70,10 +70,13 @@ def test_webhook_types_exported_from_package():
         ("schedule", "home_event_changed", WebhookKind.TOPOLOGY_DIRTY),
         ("person", "NACamera-person", WebhookKind.EVENT),
         ("movement", "NACamera-movement", WebhookKind.EVENT),
-        ("disconnection", "NACamera-disconnection", WebhookKind.EVENT),
+        ("disconnection", "NACamera-disconnection", WebhookKind.LIFECYCLE),
         (None, "webhook_activation", WebhookKind.LIFECYCLE),
         (None, "webhook_deactivation", WebhookKind.LIFECYCLE),
         ("connection", "NACamera-connection", WebhookKind.LIFECYCLE),
+        ("connection", "connection", WebhookKind.LIFECYCLE),
+        ("disconnection", "disconnection", WebhookKind.LIFECYCLE),
+        (None, "NPC-connection", WebhookKind.LIFECYCLE),
         ("something_new", "brand_new_push", WebhookKind.UNKNOWN),
     ],
 )
@@ -180,6 +183,63 @@ async def test_process_webhook_camera_connection_full_surfaces_event(async_accou
     assert result.kind is WebhookKind.LIFECYCLE
     assert result.lifecycle is LifecycleStatus.CONNECTION
     assert result.needs_refresh is True
+    assert result.touched_ids == ["12:34:56:00:f1:62"]
+    assert len(result.events) == 1
+    assert result.events[0].event_type == "connection"
+
+
+async def test_process_webhook_npc_connection_bare(async_account):
+    """NPC (Netatmo Smart Video Doorbell) reconnect, no event_type."""
+    result = await process_webhook(async_account, {"push_type": "NPC-connection"})
+    assert result.kind is WebhookKind.LIFECYCLE
+    assert result.lifecycle is LifecycleStatus.CONNECTION
+    assert result.refresh_scope is RefreshScope.STATUS
+    assert result.events == []
+
+
+@pytest.mark.usefixtures("async_home")
+async def test_process_webhook_camera_disconnection_then_connection_flips_reachable(
+    async_account,
+):
+    """Real captures, redacted: disconnection marks unreachable, connection clears it."""
+    home_id = "91763b24c43d3e344f424e8b"
+    camera_id = "12:34:56:00:f1:62"
+    camera = async_account.homes[home_id].modules[camera_id]
+    assert camera.reachable is True
+
+    result = await process_webhook(
+        async_account,
+        {
+            "event_type": "disconnection",
+            "camera_id": camera_id,
+            "device_id": camera_id,
+            "home_id": home_id,
+            "push_type": "disconnection",
+        },
+    )
+    assert result.kind is WebhookKind.LIFECYCLE
+    assert result.lifecycle is LifecycleStatus.DISCONNECTION
+    assert result.refresh_scope is None
+    assert camera.reachable is False
+    assert result.touched_ids == [camera_id]
+    assert len(result.events) == 1
+    assert result.events[0].event_type == "disconnection"
+
+    result = await process_webhook(
+        async_account,
+        {
+            "event_type": "connection",
+            "camera_id": camera_id,
+            "device_id": camera_id,
+            "home_id": home_id,
+            "push_type": "connection",
+        },
+    )
+    assert result.kind is WebhookKind.LIFECYCLE
+    assert result.lifecycle is LifecycleStatus.CONNECTION
+    assert result.refresh_scope is RefreshScope.STATUS
+    assert camera.reachable is True
+    assert result.touched_ids == [camera_id]
     assert len(result.events) == 1
     assert result.events[0].event_type == "connection"
 
@@ -1280,6 +1340,59 @@ async def test_process_webhook_device_event_modules_merges_dimmer(async_account)
 
 
 @pytest.mark.usefixtures("async_home")
+async def test_process_webhook_device_event_normalizes_weather_keys(async_account):
+    """Real capture, redacted: weather keys renamed to model attrs before merge."""
+    home_id = "91763b24c43d3e344f424e8b"
+    main_id = "12:34:56:80:bb:26"
+    child_id = "12:34:56:80:1c:42"
+    main = async_account.homes[home_id].modules[main_id]
+    child = async_account.homes[home_id].modules[child_id]
+    assert main.wifi_strength == 45
+
+    payload = {
+        "extra_params": {
+            "modules": [
+                {
+                    "id": main_id,
+                    "wifi_status": 66,
+                    "pressure_sea": 1015.3,
+                    "pressure_abs": 1011.4,
+                    "noise_current": 43,
+                    "temperature": 22,
+                    "co2": 381,
+                    "humidity": 51,
+                    "trend_temperature": "stable",
+                    "firmware": 300,
+                },
+                {
+                    "id": child_id,
+                    "temperature": 22,
+                    "humidity": 52,
+                    "rf_status": 5,
+                    "battery_vp": 5960,
+                },
+            ],
+        },
+        "push_type": "device_event",
+        "device_id": main_id,
+        "home_id": home_id,
+    }
+    result = await process_webhook(async_account, payload)
+
+    assert result.kind is WebhookKind.STATE
+    assert main_id in result.touched_ids
+    assert child_id in result.touched_ids
+    assert main.wifi_strength == 66
+    assert main.pressure == 1015.3
+    assert main.absolute_pressure == 1011.4
+    assert main.noise == 43
+    assert main.temperature == 22
+    assert main.co2 == 381
+    assert child.rf_strength == 5
+    assert child.temperature == 22
+
+
+@pytest.mark.usefixtures("async_home")
 async def test_process_webhook_device_event_modules_skips_camera(async_account):
     """Camera modules must never be merged (network I/O guard)."""
     home_id = "91763b24c43d3e344f424e8b"
@@ -1396,3 +1509,118 @@ async def test_process_webhook_device_event_temperature_variation_merges_room(
     assert len(result.events) == 1
     assert result.events[0].event_type == "temperature_variation_event"
     assert result.events[0].mode == "home"
+
+
+@pytest.mark.usefixtures("async_home")
+async def test_process_webhook_device_event_motor_data_event_merges_position(
+    async_account,
+):
+    """Real capture, remapped: current_position merges onto the fixture's NBR cover."""
+    home_id = "91763b24c43d3e344f424e8b"
+    module_id = "0009999992"
+    cover = async_account.homes[home_id].modules[module_id]
+    assert cover.current_position == 0
+
+    payload = {
+        "extra_params": {
+            "event_type": "motor_data_event",
+            "module_id": module_id,
+            "current_position": 2229,
+            "motor_cmd": 0,
+            "device_type": "NAPlug",
+            "ts": 1786426877,
+        },
+        "push_type": "device_event",
+        "device_id": "12:34:56:00:bc:24",
+        "home_id": home_id,
+    }
+    result = await process_webhook(async_account, payload)
+
+    assert result.kind is WebhookKind.STATE
+    assert result.touched_ids == [module_id]
+    assert cover.current_position == 2229
+    assert len(result.events) == 1
+    assert result.events[0].event_type == "motor_data_event"
+    assert result.events[0].module_id == module_id
+
+
+async def test_process_webhook_device_event_motor_data_event_unknown_module(
+    async_account,
+):
+    """An unresolvable module_id: no crash, touched_ids empty, event still surfaced."""
+    payload = {
+        "extra_params": {
+            "event_type": "motor_data_event",
+            "module_id": "does-not-exist",
+            "current_position": 2229,
+            "motor_cmd": 0,
+            "device_type": "NAPlug",
+            "ts": 1786426877,
+        },
+        "push_type": "device_event",
+        "device_id": "12:34:56:00:bc:24",
+        "home_id": "91763b24c43d3e344f424e8b",
+    }
+    result = await process_webhook(async_account, payload)
+
+    assert result.kind is WebhookKind.STATE
+    assert result.touched_ids == []
+    assert len(result.events) == 1
+    assert result.events[0].event_type == "motor_data_event"
+    assert result.events[0].module_id == "does-not-exist"
+
+
+@pytest.mark.usefixtures("async_home")
+async def test_process_webhook_device_event_boiler_event_surfaces_status(
+    async_account,
+):
+    """Real capture, remapped: boiler_status surfaces on the event regardless of merge.
+
+    The fixture has four boiler_status modules and none is bridged to the
+    (remapped) device_id, so the merge is ambiguous and skipped.
+    """
+    home_id = "91763b24c43d3e344f424e8b"
+    home = async_account.homes[home_id]
+    natherm1 = home.modules["12:34:56:00:01:ae"]
+    oth = home.modules["12:34:56:20:f5:44"]
+    natherm1_before = natherm1.boiler_status
+    oth_before = oth.boiler_status
+
+    payload = {
+        "extra_params": {
+            "event_type": "boiler_event",
+            "boiler_status": "boiler_on",
+            "device_type": "NAPlug",
+            "ts": 1786426877,
+        },
+        "push_type": "device_event",
+        "device_id": "12:34:56:00:bc:24",
+        "home_id": home_id,
+    }
+    result = await process_webhook(async_account, payload)
+
+    assert result.kind is WebhookKind.STATE
+    assert len(result.events) == 1
+    assert result.events[0].event_type == "boiler_event"
+    assert result.events[0].boiler_status is True
+    assert natherm1.boiler_status == natherm1_before
+    assert oth.boiler_status == oth_before
+    assert result.touched_ids == ["12:34:56:00:bc:24"]
+
+
+async def test_process_webhook_device_event_boiler_off_maps_false(async_account):
+    """boiler_off maps to False on the surfaced event."""
+    payload = {
+        "extra_params": {
+            "event_type": "boiler_event",
+            "boiler_status": "boiler_off",
+            "device_type": "NAPlug",
+            "ts": 1786426877,
+        },
+        "push_type": "device_event",
+        "device_id": "12:34:56:00:bc:24",
+        "home_id": "91763b24c43d3e344f424e8b",
+    }
+    result = await process_webhook(async_account, payload)
+
+    assert result.events[0].boiler_status is False

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -596,6 +596,131 @@ async def test_process_webhook_schedule_needs_refresh(async_account):
     assert result.touched_ids == []
 
 
+@pytest.mark.parametrize(
+    ("payload", "expected_change", "expected_touched"),
+    [
+        (
+            {
+                "change": "module_updated",
+                "device_id": "12:34:56:3c:63:b2",
+                "module_id": "12:34:56:00:01:34:64:98",
+                "home": {
+                    "id": "91763b24c43d3e344f424e8b",
+                    "modules": [
+                        {
+                            "id": "12:34:56:00:01:34:64:98",
+                            "bridge": "12:34:56:3c:63:b2",
+                            "name": "Mobile outlet 1",
+                        },
+                    ],
+                },
+                "push_type": "topology_changed",
+            },
+            "module_updated",
+            ["12:34:56:3c:63:b2", "12:34:56:00:01:34:64:98"],
+        ),
+        (
+            {
+                "change": "module_assigned_to_room",
+                "home_id": "91763b24c43d3e344f424e8b",
+                "module_id": "12:34:56:00:01:34:64:98",
+                "device_id": "12:34:56:3c:63:b2",
+                "room_id": "2313121935",
+                "home": {
+                    "id": "91763b24c43d3e344f424e8b",
+                    "modules": [
+                        {
+                            "id": "12:34:56:00:01:34:64:98",
+                            "bridge": "12:34:56:3c:63:b2",
+                            "room": "2313121935",
+                        },
+                    ],
+                },
+                "push_type": "topology_changed",
+            },
+            "module_assigned_to_room",
+            ["12:34:56:3c:63:b2", "12:34:56:00:01:34:64:98"],
+        ),
+        (
+            {
+                "change": "device_updated",
+                "device_id": "12:34:56:3c:63:b2",
+                "home_id": "91763b24c43d3e344f424e8b",
+                "home": {
+                    "id": "91763b24c43d3e344f424e8b",
+                    "modules": [
+                        {
+                            "id": "12:34:56:00:01:2b:02:46",
+                            "bridge": "12:34:56:3c:63:b2",
+                        },
+                    ],
+                },
+                "push_type": "topology_changed",
+            },
+            "device_updated",
+            ["12:34:56:3c:63:b2"],
+        ),
+    ],
+)
+async def test_process_webhook_topology_changed_variants(
+    async_account,
+    payload,
+    expected_change,
+    expected_touched,
+):
+    """Real `topology_changed` captures route to TOPOLOGY_DIRTY, not UNKNOWN.
+
+    Covers the three observed `change` variants: module_updated,
+    module_assigned_to_room, device_updated. `event_type` carries the
+    `change` value; `touched_ids` is the deduped device_id/module_id set from
+    `_touched_from_payload` (device_id before module_id).
+    """
+    result = await process_webhook(async_account, payload)
+
+    assert result.kind is WebhookKind.TOPOLOGY_DIRTY
+    assert result.needs_refresh is True
+    assert result.event_type == expected_change
+    assert result.touched_ids == expected_touched
+
+
+@pytest.mark.usefixtures("async_home")
+async def test_process_webhook_topology_changed_does_not_merge_modules(async_account):
+    """The partial `home.modules[]` in a `topology_changed` payload is not applied.
+
+    A full `async_update_topology` refresh (signalled by `needs_refresh`) is
+    the authoritative way to pick up structural changes -- merging the partial
+    list here would risk creating a half-initialized module.
+    """
+    home_id = "91763b24c43d3e344f424e8b"
+    home = async_account.homes[home_id]
+    module_count_before = len(home.modules)
+    known_module_id = "12:34:56:00:01:ae"  # NATherm1, in fixture
+    assert known_module_id in home.modules
+
+    payload = {
+        "change": "module_updated",
+        "device_id": "12:34:56:3c:63:b2",
+        "module_id": "12:34:56:00:01:34:64:98",
+        "home": {
+            "id": home_id,
+            "modules": [
+                {
+                    "id": "12:34:56:00:01:34:64:98",
+                    "bridge": "12:34:56:3c:63:b2",
+                    "name": "Mobile outlet 1",
+                },
+            ],
+        },
+        "push_type": "topology_changed",
+    }
+    result = await process_webhook(async_account, payload)
+
+    assert result.kind is WebhookKind.TOPOLOGY_DIRTY
+    assert len(home.modules) == module_count_before
+    assert "12:34:56:00:01:34:64:98" not in home.modules
+    assert known_module_id in home.modules
+
+
 async def test_account_process_webhook_delegates(async_account):
     result = await async_account.process_webhook({"push_type": "webhook_activation"})
     assert result.kind is WebhookKind.LIFECYCLE

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -10,6 +10,7 @@ from pyatmo.room import Room
 from pyatmo.webhook import (
     _ROOM_SETPOINT_KEYS,
     LifecycleStatus,
+    RefreshScope,
     WebhookEvent,
     WebhookKind,
     WebhookResult,
@@ -30,6 +31,7 @@ def test_webhook_result_defaults():
     assert result.touched_ids == []
     assert result.events == []
     assert result.needs_refresh is False
+    assert result.refresh_scope is None
     assert result.lifecycle is None
 
 
@@ -45,6 +47,7 @@ def test_webhook_types_exported_from_package():
     assert pyatmo.WebhookKind is WebhookKind
     assert pyatmo.WebhookEvent is WebhookEvent
     assert pyatmo.LifecycleStatus is LifecycleStatus
+    assert pyatmo.RefreshScope is RefreshScope
 
 
 @pytest.mark.parametrize(
@@ -117,6 +120,7 @@ async def test_process_webhook_activation(async_account):
     assert result.kind is WebhookKind.LIFECYCLE
     assert result.lifecycle is LifecycleStatus.ACTIVATION
     assert result.needs_refresh is False
+    assert result.refresh_scope is None
 
 
 async def test_process_webhook_deactivation(async_account):
@@ -126,6 +130,8 @@ async def test_process_webhook_deactivation(async_account):
     )
     assert result.kind is WebhookKind.LIFECYCLE
     assert result.lifecycle is LifecycleStatus.DEACTIVATION
+    assert result.needs_refresh is False
+    assert result.refresh_scope is None
 
 
 async def test_process_webhook_camera_connection_needs_refresh(async_account):
@@ -136,6 +142,7 @@ async def test_process_webhook_camera_connection_needs_refresh(async_account):
     assert result.kind is WebhookKind.LIFECYCLE
     assert result.lifecycle is LifecycleStatus.CONNECTION
     assert result.needs_refresh is True
+    assert result.refresh_scope is RefreshScope.STATUS
 
 
 async def test_process_webhook_unknown(async_account):
@@ -184,6 +191,7 @@ async def test_process_webhook_movement_event(async_account):
     assert result.kind is WebhookKind.EVENT
     assert result.events[0].event_type == "movement"
     assert result.touched_ids == ["12:34:56:00:f1:62"]
+    assert result.refresh_scope is None
 
 
 @pytest.mark.usefixtures("async_home")
@@ -348,6 +356,7 @@ async def test_process_webhook_therm_mode_updates_home(async_account):
     assert result.kind is WebhookKind.STATE
     assert result.touched_ids == [home_id]
     assert home.therm_mode == "hg"
+    assert result.refresh_scope is None
 
 
 @pytest.mark.usefixtures("async_home")
@@ -593,6 +602,7 @@ async def test_process_webhook_schedule_needs_refresh(async_account):
     result = await process_webhook(async_account, payload)
     assert result.kind is WebhookKind.TOPOLOGY_DIRTY
     assert result.needs_refresh is True
+    assert result.refresh_scope is RefreshScope.TOPOLOGY
     assert result.touched_ids == []
 
 
@@ -679,6 +689,7 @@ async def test_process_webhook_topology_changed_variants(
 
     assert result.kind is WebhookKind.TOPOLOGY_DIRTY
     assert result.needs_refresh is True
+    assert result.refresh_scope is RefreshScope.TOPOLOGY
     assert result.event_type == expected_change
     assert result.touched_ids == expected_touched
 

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -14,7 +14,7 @@ from pyatmo.webhook import (
     WebhookEvent,
     WebhookKind,
     WebhookResult,
-    build_webhook_event,
+    build_webhook_events,
     classify,
     process_webhook,
     resolve_home_id,
@@ -37,7 +37,14 @@ def test_webhook_result_defaults():
 
 def test_webhook_event_defaults():
     event = WebhookEvent(event_type="person", push_type="NACamera-person", home_id="h1")
-    assert event.person_ids == []
+    assert event.person_id is None
+    assert event.person_name is None
+    assert event.is_known is None
+    assert event.face_url is None
+    assert event.room_id is None
+    assert event.mode is None
+    assert event.vignette_url is None
+    assert event.event_id is None
     assert event.raw == {}
     assert event.camera_id is None
 
@@ -90,7 +97,7 @@ def test_resolve_home_id_missing():
     assert resolve_home_id({"event_type": "on"}) is None
 
 
-def test_build_webhook_event_person():
+def test_build_webhook_events_person_fan_out():
     payload = {
         "persons": [
             {"id": "p1", "is_known": True},
@@ -104,15 +111,24 @@ def test_build_webhook_event_person():
         "message": "seen",
         "push_type": "NACamera-person",
     }
-    event = build_webhook_event(payload)
-    assert event.event_type == "person"
-    assert event.push_type == "NACamera-person"
-    assert event.home_id == "h1"
-    assert event.camera_id == "cam1"
-    assert event.person_ids == ["p1", "p2"]
-    assert event.snapshot_url == "https://example/snap"
-    assert event.message == "seen"
-    assert event.raw is payload
+    events = build_webhook_events(payload, home=None)
+    assert len(events) == 2
+
+    first, second = events
+    assert first.event_type == "person"
+    assert first.push_type == "NACamera-person"
+    assert first.home_id == "h1"
+    assert first.camera_id == "cam1"
+    assert first.snapshot_url == "https://example/snap"
+    assert first.message == "seen"
+    assert first.raw is payload
+    assert first.person_id == "p1"
+    assert first.is_known is True
+    # no home passed -> name unresolved
+    assert first.person_name is None
+
+    assert second.person_id == "p2"
+    assert second.is_known is False
 
 
 async def test_process_webhook_activation(async_account):
@@ -121,6 +137,7 @@ async def test_process_webhook_activation(async_account):
     assert result.lifecycle is LifecycleStatus.ACTIVATION
     assert result.needs_refresh is False
     assert result.refresh_scope is None
+    assert result.events == []
 
 
 async def test_process_webhook_deactivation(async_account):
@@ -132,9 +149,11 @@ async def test_process_webhook_deactivation(async_account):
     assert result.lifecycle is LifecycleStatus.DEACTIVATION
     assert result.needs_refresh is False
     assert result.refresh_scope is None
+    assert result.events == []
 
 
 async def test_process_webhook_camera_connection_needs_refresh(async_account):
+    """Bare reconnect: no event_type -> no event."""
     result = await process_webhook(
         async_account,
         {"push_type": "NACamera-connection"},
@@ -143,6 +162,26 @@ async def test_process_webhook_camera_connection_needs_refresh(async_account):
     assert result.lifecycle is LifecycleStatus.CONNECTION
     assert result.needs_refresh is True
     assert result.refresh_scope is RefreshScope.STATUS
+    assert result.events == []
+
+
+async def test_process_webhook_camera_connection_full_surfaces_event(async_account):
+    """Full reconnect payload: event_type present -> surfaces an event."""
+    result = await process_webhook(
+        async_account,
+        {
+            "event_type": "connection",
+            "push_type": "NACamera-connection",
+            "camera_id": "12:34:56:00:f1:62",
+            "device_id": "12:34:56:00:f1:62",
+            "home_id": "91763b24c43d3e344f424e8b",
+        },
+    )
+    assert result.kind is WebhookKind.LIFECYCLE
+    assert result.lifecycle is LifecycleStatus.CONNECTION
+    assert result.needs_refresh is True
+    assert len(result.events) == 1
+    assert result.events[0].event_type == "connection"
 
 
 async def test_process_webhook_unknown(async_account):
@@ -176,7 +215,9 @@ async def test_process_webhook_person_event(async_account):
     assert len(result.events) == 1
     event = result.events[0]
     assert event.event_type == "person"
-    assert event.person_ids == ["91827374-7e04-5298-83ad-a0cb8372dff1"]
+    assert event.person_id == "91827374-7e04-5298-83ad-a0cb8372dff1"
+    assert event.is_known is True
+    assert event.person_name == "John Doe"
 
 
 async def test_process_webhook_movement_event(async_account):
@@ -194,14 +235,69 @@ async def test_process_webhook_movement_event(async_account):
     assert result.refresh_scope is None
 
 
+async def test_process_webhook_camera_human_event(async_account):
+    """Real camera `human` capture, redacted."""
+    payload = {
+        "snapshot_id": "6a7ab5a5616f56de6c0ea337",
+        "snapshot_url": "https://example/snapshot.jpg",
+        "vignette_id": "6a7ab5a5616f56de6c0ea338",
+        "vignette_url": "https://example/vignette.jpg",
+        "event_type": "human",
+        "camera_id": "12:34:56:00:f1:62",
+        "device_id": "12:34:56:00:f1:62",
+        "home_id": "91763b24c43d3e344f424e8b",
+        "event_id": "6a7ab5a5a5d9e433642e230c",
+        "message": "Person erfasst Esszimmer",
+        "push_type": "NACamera-human",
+    }
+    result = await process_webhook(async_account, payload)
+
+    assert result.kind is WebhookKind.EVENT
+    assert len(result.events) == 1
+    event = result.events[0]
+    assert event.event_type == "human"
+    assert event.camera_id == "12:34:56:00:f1:62"
+    assert event.snapshot_url == "https://example/snapshot.jpg"
+    assert event.vignette_url == "https://example/vignette.jpg"
+    assert event.event_id == "6a7ab5a5a5d9e433642e230c"
+    assert event.message == "Person erfasst Esszimmer"
+
+
+async def test_process_webhook_person_event_fan_out_two_persons(async_account):
+    """One known id (name resolves), one unknown (name stays None)."""
+    payload = {
+        "persons": [
+            {"id": "91827374-7e04-5298-83ad-a0cb8372dff1", "is_known": True},
+            {"id": "unknown-person-id-0001", "is_known": False},
+        ],
+        "event_type": "person",
+        "camera_id": "12:34:56:00:f1:62",
+        "device_id": "12:34:56:00:f1:62",
+        "home_id": "91763b24c43d3e344f424e8b",
+        "push_type": "NACamera-person",
+    }
+    result = await process_webhook(async_account, payload)
+
+    assert result.kind is WebhookKind.EVENT
+    assert len(result.events) == 2
+
+    known, unknown = result.events
+    assert known.person_id == "91827374-7e04-5298-83ad-a0cb8372dff1"
+    assert known.is_known is True
+    assert known.person_name == "John Doe"
+
+    assert unknown.person_id == "unknown-person-id-0001"
+    assert unknown.is_known is False
+    assert unknown.person_name is None
+
+
 @pytest.mark.usefixtures("async_home")
 async def test_process_webhook_set_point_updates_room(async_account):
-    # async_home loads status for this home; async_account is its parent.
     home_id = "91763b24c43d3e344f424e8b"
     room = async_account.homes[home_id].rooms["2746182631"]
-    assert room.therm_setpoint_mode == "away"  # precondition from fixture
-    assert room.therm_measured_temperature == 19.8  # precondition from fixture
-    assert room.reachable is True  # precondition from fixture
+    assert room.therm_setpoint_mode == "away"
+    assert room.therm_measured_temperature == 19.8
+    assert room.reachable is True
 
     payload = {
         "room_id": "2746182631",
@@ -233,23 +329,19 @@ async def test_process_webhook_set_point_updates_room(async_account):
     assert result.touched_ids == ["2746182631"]
     assert room.therm_setpoint_mode == "manual"
     assert room.therm_setpoint_temperature == 21
-    # Telemetry not present in the webhook payload must be preserved, not wiped.
+    # preserved, not wiped
     assert room.therm_measured_temperature == 19.8
     assert room.reachable is True
 
 
 @pytest.mark.usefixtures("async_home")
 async def test_process_webhook_setpoint_event_alias_merges_room(async_account):
-    """Real `display_change` payloads use `setpoint_event`, not `set_point`.
-
-    Redacted/remapped real capture: home/room ids point at the fixture home,
-    `user_id` dropped.
-    """
+    """Real capture: `display_change` uses `setpoint_event`, not `set_point`."""
     home_id = "91763b24c43d3e344f424e8b"
     room = async_account.homes[home_id].rooms["2746182631"]
-    assert room.therm_setpoint_mode == "away"  # precondition from fixture
-    assert room.therm_setpoint_temperature == 12  # precondition from fixture
-    assert room.therm_measured_temperature == 19.8  # precondition from fixture
+    assert room.therm_setpoint_mode == "away"
+    assert room.therm_setpoint_temperature == 12
+    assert room.therm_measured_temperature == 19.8
 
     payload = {
         "home": {
@@ -280,8 +372,11 @@ async def test_process_webhook_setpoint_event_alias_merges_room(async_account):
     assert result.touched_ids == ["2746182631"]
     assert room.therm_setpoint_mode == "manual"
     assert room.therm_setpoint_temperature == 13.5
-    # Telemetry not present in the webhook payload must be preserved, not wiped.
+    # preserved, not wiped
     assert room.therm_measured_temperature == 19.8
+    assert len(result.events) == 1
+    assert result.events[0].event_type == "setpoint_event"
+    assert result.events[0].mode == "manual"
 
 
 @pytest.mark.usefixtures("async_home")
@@ -342,7 +437,7 @@ async def test_process_webhook_set_point_unknown_home_no_mutation(async_account)
 async def test_process_webhook_therm_mode_updates_home(async_account):
     home_id = "91763b24c43d3e344f424e8b"
     home = async_account.homes[home_id]
-    assert home.therm_mode == "schedule"  # precondition from fixture
+    assert home.therm_mode == "schedule"
 
     payload = {
         "event_type": "therm_mode",
@@ -360,6 +455,29 @@ async def test_process_webhook_therm_mode_updates_home(async_account):
 
 
 @pytest.mark.usefixtures("async_home")
+async def test_process_webhook_therm_mode_real_capture_surfaces_event(async_account):
+    """Real capture, redacted: STATE result also carries a matching event."""
+    home_id = "91763b24c43d3e344f424e8b"
+    home = async_account.homes[home_id]
+    assert home.therm_mode == "schedule"
+
+    payload = {
+        "home_id": home_id,
+        "event_type": "therm_mode",
+        "home": {"id": home_id, "therm_mode": "away"},
+        "mode": "away",
+        "push_type": "home_event_changed",
+    }
+    result = await process_webhook(async_account, payload)
+
+    assert result.kind is WebhookKind.STATE
+    assert home.therm_mode == "away"
+    assert len(result.events) == 1
+    assert result.events[0].event_type == "therm_mode"
+    assert result.events[0].mode == "away"
+
+
+@pytest.mark.usefixtures("async_home")
 @pytest.mark.parametrize(
     "home_block",
     [None, "x", {"id": "91763b24c43d3e344f424e8b"}],
@@ -370,7 +488,7 @@ async def test_process_webhook_therm_mode_without_mode_touches_nothing(
 ):
     home_id = "91763b24c43d3e344f424e8b"
     home = async_account.homes[home_id]
-    assert home.therm_mode == "schedule"  # precondition from fixture
+    assert home.therm_mode == "schedule"
 
     payload = {
         "event_type": "therm_mode",
@@ -392,7 +510,7 @@ async def test_process_webhook_camera_off(async_account):
     home_id = "91763b24c43d3e344f424e8b"
     camera_id = "12:34:56:00:f1:62"
     camera = async_account.homes[home_id].modules[camera_id]
-    assert camera.monitoring is True  # precondition from fixture
+    assert camera.monitoring is True
 
     payload = {
         "event_type": "off",
@@ -562,7 +680,7 @@ async def test_process_webhook_light_mode_without_sub_type_keeps_value(
     home_id = "91763b24c43d3e344f424e8b"
     camera_id = "12:34:56:10:b9:0e"  # NOC, has floodlight attr
     camera = async_account.homes[home_id].modules[camera_id]
-    assert camera.floodlight == "auto"  # precondition from fixture
+    assert camera.floodlight == "auto"
 
     payload = {
         "event_type": "light_mode",
@@ -678,13 +796,7 @@ async def test_process_webhook_topology_changed_variants(
     expected_change,
     expected_touched,
 ):
-    """Real `topology_changed` captures route to TOPOLOGY_DIRTY, not UNKNOWN.
-
-    Covers the three observed `change` variants: module_updated,
-    module_assigned_to_room, device_updated. `event_type` carries the
-    `change` value; `touched_ids` is the deduped device_id/module_id set from
-    `_touched_from_payload` (device_id before module_id).
-    """
+    """Covers the three observed `change` variants; real captures, redacted."""
     result = await process_webhook(async_account, payload)
 
     assert result.kind is WebhookKind.TOPOLOGY_DIRTY
@@ -692,16 +804,12 @@ async def test_process_webhook_topology_changed_variants(
     assert result.refresh_scope is RefreshScope.TOPOLOGY
     assert result.event_type == expected_change
     assert result.touched_ids == expected_touched
+    assert result.events == []
 
 
 @pytest.mark.usefixtures("async_home")
 async def test_process_webhook_topology_changed_does_not_merge_modules(async_account):
-    """The partial `home.modules[]` in a `topology_changed` payload is not applied.
-
-    A full `async_update_topology` refresh (signalled by `needs_refresh`) is
-    the authoritative way to pick up structural changes -- merging the partial
-    list here would risk creating a half-initialized module.
-    """
+    """Partial `home.modules[]` is not applied; a full refresh is authoritative."""
     home_id = "91763b24c43d3e344f424e8b"
     home = async_account.homes[home_id]
     module_count_before = len(home.modules)
@@ -792,7 +900,9 @@ async def test_process_webhook_malformed_persons_no_raise(async_account, persons
 
     assert result.kind is WebhookKind.EVENT
     assert result.touched_ids == []
-    assert result.events[0].person_ids == []
+    # No usable persons[] -> falls back to a single event, person_id unset.
+    assert len(result.events) == 1
+    assert result.events[0].person_id is None
 
 
 @pytest.mark.parametrize("rooms", [None, ["x"]])
@@ -904,7 +1014,7 @@ async def test_process_webhook_non_str_sub_type_keeps_model_clean(async_account)
     home_id = "91763b24c43d3e344f424e8b"
     camera_id = "12:34:56:10:b9:0e"  # NOC, has floodlight attr
     camera = async_account.homes[home_id].modules[camera_id]
-    assert camera.floodlight == "auto"  # precondition from fixture
+    assert camera.floodlight == "auto"
 
     result = await process_webhook(
         async_account,
@@ -926,7 +1036,7 @@ async def test_process_webhook_non_str_therm_mode_keeps_model_clean(async_accoun
     """A malformed therm_mode must not land on the home's therm_mode attribute."""
     home_id = "91763b24c43d3e344f424e8b"
     home = async_account.homes[home_id]
-    assert home.therm_mode == "schedule"  # precondition from fixture
+    assert home.therm_mode == "schedule"
 
     result = await process_webhook(
         async_account,
@@ -942,7 +1052,7 @@ async def test_process_webhook_non_str_therm_mode_keeps_model_clean(async_accoun
 
 
 async def test_process_webhook_person_ids_are_strings(async_account):
-    """Non-string person ids are dropped, matching the touched_ids guard."""
+    """Fan-out is per raw person entry, not a filtered list of valid ids."""
     result = await process_webhook(
         async_account,
         {
@@ -953,7 +1063,8 @@ async def test_process_webhook_person_ids_are_strings(async_account):
         },
     )
 
-    assert result.events[0].person_ids == ["p1"]
+    assert len(result.events) == 3
+    assert [event.person_id for event in result.events] == [None, None, "p1"]
 
 
 async def test_process_webhook_event_id_fields_are_strings(async_account):
@@ -979,8 +1090,8 @@ async def test_process_webhook_set_point_rejects_wrongly_typed_values(async_acco
     """A malformed setpoint value is dropped, preserving the known-good value."""
     home_id = "91763b24c43d3e344f424e8b"
     room = async_account.homes[home_id].rooms["2746182631"]
-    assert room.therm_setpoint_mode == "away"  # precondition from fixture
-    assert room.therm_setpoint_temperature == 12  # precondition from fixture
+    assert room.therm_setpoint_mode == "away"
+    assert room.therm_setpoint_temperature == 12
 
     result = await process_webhook(
         async_account,
@@ -1032,7 +1143,7 @@ async def test_process_webhook_set_point_explicit_null_clears_value(async_accoun
     """An explicit `null` clears the field; only wrong types are rejected."""
     home_id = "91763b24c43d3e344f424e8b"
     room = async_account.homes[home_id].rooms["2746182631"]
-    assert room.therm_setpoint_mode == "away"  # precondition from fixture
+    assert room.therm_setpoint_mode == "away"
 
     result = await process_webhook(
         async_account,
@@ -1095,13 +1206,7 @@ async def test_process_webhook_set_point_without_setpoint_keys_reports_nothing(
 
 
 def test_room_setpoint_keys_match_room_annotations():
-    """Every coercer matches the type `Room` declares for that field.
-
-    `_ROOM_SETPOINT_KEYS` duplicates type knowledge that already lives on
-    `Room`, so drift would silently reject a valid value rather than fail. This
-    pins the two together. Read `__annotations__` directly: `get_type_hints`
-    cannot resolve `Room`'s `TYPE_CHECKING`-only names.
-    """
+    """Pins `_ROOM_SETPOINT_KEYS` coercers to `Room`'s declared types."""
     coercer_for = {
         "str|None": str_or_none,
         "int|None": number_or_none,
@@ -1118,15 +1223,7 @@ def test_room_setpoint_keys_match_room_annotations():
 
 
 async def test_process_webhook_never_suspends(async_account):
-    """`process_webhook` must run to completion without yielding to the loop.
-
-    Netatmo requires a webhook endpoint to answer immediately and deactivates
-    one that does not, so the merge deliberately performs no I/O. Awaiting
-    anything here -- an `async_update_*` refresh being the tempting one -- would
-    put network latency, including the 429 backoff in `auth.py`, on the response
-    path. Driving the coroutine one step must therefore finish it: a suspension
-    yields instead of raising `StopIteration`.
-    """
+    """A suspension would yield instead of raising `StopIteration`."""
     payload = {
         "event_type": "movement",
         "push_type": "NACamera-movement",
@@ -1143,16 +1240,12 @@ async def test_process_webhook_never_suspends(async_account):
 
 @pytest.mark.usefixtures("async_home")
 async def test_process_webhook_device_event_modules_merges_dimmer(async_account):
-    """The `device_event` envelope's `extra_params.modules[]` merges via Module.update.
-
-    Redacted/remapped real capture: dimmer id points at the fixture's NLF
-    module (fixture start: on=False, brightness=63).
-    """
+    """Real capture, remapped to the fixture's NLF dimmer."""
     home_id = "91763b24c43d3e344f424e8b"
     module_id = "00:11:22:33:00:11:45:fe"
     dimmer = async_account.homes[home_id].modules[module_id]
-    assert dimmer.on is False  # precondition from fixture
-    assert dimmer.brightness == 63  # precondition from fixture
+    assert dimmer.on is False
+    assert dimmer.brightness == 63
 
     payload = {
         "extra_params": {
@@ -1181,17 +1274,14 @@ async def test_process_webhook_device_event_modules_merges_dimmer(async_account)
     assert result.touched_ids == [module_id]
     assert dimmer.on is True
     assert dimmer.brightness == 33
+    assert len(result.events) == 1
+    assert result.events[0].event_type is None
+    assert result.events[0].module_id == module_id
 
 
 @pytest.mark.usefixtures("async_home")
 async def test_process_webhook_device_event_modules_skips_camera(async_account):
-    """A camera named in `extra_params.modules[]` must never be merged.
-
-    `Camera.update` performs network I/O (`async_update_camera_urls`), which
-    must never run on the webhook response path. Current real captures only
-    carry dimmers/switches, but this guards defensively against a future
-    payload naming a camera.
-    """
+    """Camera modules must never be merged (network I/O guard)."""
     home_id = "91763b24c43d3e344f424e8b"
     camera_id = "12:34:56:00:f1:62"  # NACamera, in fixture
 
@@ -1210,28 +1300,27 @@ async def test_process_webhook_device_event_modules_skips_camera(async_account):
 
 
 @pytest.mark.usefixtures("async_home")
-async def test_process_webhook_device_event_energy_setpoint_no_merge(async_account):
-    """An `extra_params.event_type` energy event surfaces as EVENT, no merge.
-
-    Netatmo also sends the same change as a top-level `display_change`
-    payload, which is the authoritative, cleanly-keyed source for the room
-    merge; merging this differently-keyed variant too would double-apply.
-    """
+async def test_process_webhook_device_event_setpoint_event_merges_measured_temperature(
+    async_account,
+):
+    """Real capture, remapped: touched_ids is the room, not the NAPlug relay (S7)."""
     home_id = "91763b24c43d3e344f424e8b"
     room = async_account.homes[home_id].rooms["2746182631"]
-    assert room.therm_setpoint_mode == "away"  # precondition from fixture
+    assert room.therm_measured_temperature == 19.8
+    assert room.therm_setpoint_mode == "away"
+    assert room.therm_setpoint_temperature == 12
 
     payload = {
         "extra_params": {
             "device_type": "NAPlug",
             "event_type": "setpoint_event",
-            "mode": "manual",
+            "mode": "home",
             "room_id": "2746182631",
-            "temperature": 13.5,
+            "temperature": 16,
             "therm_measured_temperature": 23.3,
-            "ts": 1786428434,
-            "ts_begin": 1786428433,
-            "ts_end": 1786439233,
+            "ts": 1786428073,
+            "ts_begin": 0,
+            "ts_end": 0,
         },
         "push_type": "device_event",
         "device_id": "12:34:56:00:bc:24",
@@ -1239,11 +1328,15 @@ async def test_process_webhook_device_event_energy_setpoint_no_merge(async_accou
     }
     result = await process_webhook(async_account, payload)
 
-    assert result.kind is WebhookKind.EVENT
-    assert result.events[0].event_type == "setpoint_event"
-    assert result.touched_ids == ["12:34:56:00:bc:24"]
-    # No speculative merge: the room's setpoint must be untouched by this path.
+    assert result.kind is WebhookKind.STATE
+    assert result.touched_ids == ["2746182631"]
+    assert room.therm_measured_temperature == 23.3
+    # setpoint not applied; only display_change is authoritative for that
     assert room.therm_setpoint_mode == "away"
+    assert room.therm_setpoint_temperature == 12
+    assert len(result.events) == 1
+    assert result.events[0].event_type == "setpoint_event"
+    assert result.events[0].mode == "home"
 
 
 async def test_process_webhook_device_event_unknown_home_no_mutation(async_account):
@@ -1272,8 +1365,15 @@ async def test_process_webhook_device_event_empty_extra_params(async_account):
     assert result.kind is WebhookKind.UNKNOWN
 
 
-async def test_process_webhook_device_event_temperature_variation(async_account):
-    """A second energy-event shape (`temperature_variation_event`) surfaces as EVENT."""
+@pytest.mark.usefixtures("async_home")
+async def test_process_webhook_device_event_temperature_variation_merges_room(
+    async_account,
+):
+    """Real capture, remapped; keyed under `temperature`, not `therm_measured_temperature`."""
+    home_id = "91763b24c43d3e344f424e8b"
+    room = async_account.homes[home_id].rooms["2746182631"]
+    assert room.therm_measured_temperature == 19.8
+
     payload = {
         "extra_params": {
             "device_type": "NAPlug",
@@ -1286,9 +1386,13 @@ async def test_process_webhook_device_event_temperature_variation(async_account)
         },
         "push_type": "device_event",
         "device_id": "12:34:56:00:bc:24",
-        "home_id": "91763b24c43d3e344f424e8b",
+        "home_id": home_id,
     }
     result = await process_webhook(async_account, payload)
 
-    assert result.kind is WebhookKind.EVENT
+    assert result.kind is WebhookKind.STATE
+    assert result.touched_ids == ["2746182631"]
+    assert room.therm_measured_temperature == 23.5
+    assert len(result.events) == 1
     assert result.events[0].event_type == "temperature_variation_event"
+    assert result.events[0].mode == "home"


### PR DESCRIPTION
## Summary by Sourcery

Add support for parsing and merging Netatmo webhook payloads into the in-memory account model while hardening type handling for incoming data.

New Features:
- Introduce webhook processing utilities and result/event types to classify, normalize, and merge Netatmo webhook payloads without performing I/O.
- Expose webhook-related types and a webhook processing entry point through the public package and account API.

Enhancements:
- Harden helper utilities to safely coerce or discard malformed scalar and list values, preventing bad webhook payloads from corrupting IDs or model state.
- Improve ID normalization and module iteration in station data fixing logic to better tolerate malformed input.

Documentation:
- Document the addition of webhook payload processing in the changelog.

Tests:
- Add extensive unit tests for webhook classification, merging behavior, and safety guarantees, as well as for the new helper functions and updated ID-fixing logic.