### PR TITLE
fix: resolve sub-module reachability from the parent module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Report the actually selected schedule after a schedule switch
 
+### Changed
+
+- `Module.reachable` is now a read-only property that resolves `#`-suffixed
+  sub-modules from their parent module. Use `Module.mark_unreachable()` instead
+  of assigning to it.
+
+### Fixed
+
+- Reachability of `#`-suffixed sub-modules now resolves from the parent module,
+  so Legrand NLIS double switches are no longer reported unreachable
+  ([home-assistant/core#178403](https://github.com/home-assistant/core/issues/178403))
+- An absent `reachable` key in a `/homestatus` payload now preserves the
+  previous value instead of meaning "unreachable". Modules that never report the
+  key (weather stations, OTH, VELUX gateways) are no longer pinned unreachable,
+  and their bridged children are no longer overwritten with the parent module's
+  readings on every poll
+
 ## [9.6.0] - 2026-07-28
 
 ### Added

--- a/src/pyatmo/home.py
+++ b/src/pyatmo/home.py
@@ -202,6 +202,10 @@ class Home:
             has_error = True
             module_id = module["id"]
             if module_id in self.modules:
+                # Mark BEFORE update({}): reflection now preserves the value, so
+                # the False survives and still drives the bridged-children and
+                # room cascade inside Module.update.
+                self.modules[module_id].mark_unreachable()
                 await self.modules[module_id].update({})
                 # Set error_code AFTER update({}): update() reruns reflection
                 # (_update_attributes) which would otherwise reset it to None.

--- a/src/pyatmo/modules/base_class.py
+++ b/src/pyatmo/modules/base_class.py
@@ -46,7 +46,9 @@ NETATMO_ATTRIBUTES_MAP: dict[str, Callable[[dict[str, Any], Any], Any]] = {
     "modules": bridged_module_ids,
     "device_type": lambda x, y: DeviceType(x.get("type", y)),
     "event_type": lambda x, y: EventTypes(x.get("type", y)),
-    "reachable": lambda x, _: x.get("reachable", False),
+    # Keyed on the private attribute: an absent `reachable` key means the API
+    # did not report it, not that the module is unreachable.
+    "_reachable": lambda x, y: x.get("reachable", y),
     "monitoring": lambda x, _: x.get("monitoring", False) == "on",
     "battery_level": lambda x, _: x.get("battery_vp", x.get("battery_level")),
     "place": lambda x, y: Place(x["place"]) if isinstance(x.get("place"), dict) else y,

--- a/src/pyatmo/modules/module.py
+++ b/src/pyatmo/modules/module.py
@@ -76,6 +76,7 @@ ATTRIBUTE_FILTER = {
     "boiler_error",
     "dhw_control",
     "error_code",
+    "_reachable",
     "rf_state",
 }
 
@@ -1289,7 +1290,7 @@ class Module(NetatmoBase):
     room_id: str | None
 
     modules: list[str] | None
-    reachable: bool | None
+    _reachable: bool | None
     last_seen: int | None
     setup_date: int | None
     error_code: int | None
@@ -1304,7 +1305,7 @@ class Module(NetatmoBase):
 
         self.home = home
         self.room_id = module.get("room_id")
-        self.reachable = module.get("reachable")
+        self._reachable = module.get("reachable")
         self.last_seen = module.get("last_seen")
         self.setup_date = module.get("setup_date")
         self.error_code = None
@@ -1312,6 +1313,35 @@ class Module(NetatmoBase):
         self.modules = bridged_module_ids(module)
         self.device_category = DEVICE_CATEGORY_MAP.get(self.device_type)
         self.features = set()
+
+    @property
+    def reachable(self) -> bool | None:
+        """Return reachability, falling back to the parent for sub-modules.
+
+        The API reports `reachable` only on the parent entry of a multi-gang
+        module such as the Legrand NLIS, so a `#`-suffixed sub-module resolves
+        it from the parent. Resolving on read keeps this independent of the
+        order modules appear in the /homestatus payload.
+        """
+        if self._reachable is not None or "#" not in self.entity_id:
+            return self._reachable
+        parent = self.home.modules.get(self.entity_id.split("#", 1)[0])
+        return parent.reachable if parent else None
+
+    def mark_unreachable(self) -> None:
+        """Mark this module and its bridged children unreachable.
+
+        Sub-modules are skipped on purpose: a `#`-suffixed id resolves its
+        reachability from the parent module on read, and its own payload never
+        reports the key, so stamping it here would pin it unreachable for the
+        lifetime of the process.
+        """
+        self._reachable = False
+        for module_id in self.modules or []:
+            if "#" in module_id:
+                continue
+            if (module := self.home.modules.get(module_id)) is not None:
+                module.mark_unreachable()
 
     async def update(self, raw_data: RawData) -> None:
         """Update module with the latest data."""
@@ -1332,10 +1362,10 @@ class Module(NetatmoBase):
         if self.device_type == DeviceType.NLE:
             # if there is a bridge it means it is a leaf
             if self.bridge:
-                self.reachable = True
+                self._reachable = True
             elif self.modules:
                 # this NLE is a bridge itself : make it not available
-                self.reachable = False
+                self._reachable = False
 
         if not self.reachable and self.modules:
             # Update bridged modules and associated rooms
@@ -1349,6 +1379,9 @@ class Module(NetatmoBase):
         """Update features."""
 
         self.features.update({var for var in vars(self) if var not in ATTRIBUTE_FILTER})
+        # Every module carries `_reachable`, so this feature is universal — unlike
+        # `battery` below. Consumers gate entity creation on the public name.
+        self.features.add("reachable")
         if "battery_state" in vars(self) or "battery_percent" in vars(self):
             self.features.add("battery")
         if "wind_angle" in self.features:

--- a/tests/test_home.py
+++ b/tests/test_home.py
@@ -18,7 +18,7 @@ from pyatmo.enums import (
     WindUnit,
 )
 from pyatmo.home import Home, get_temperature_control_mode
-from tests.common import MockResponse
+from tests.common import MockResponse, load_fixture
 
 
 async def test_async_home(async_home):
@@ -280,6 +280,9 @@ async def test_async_home_module_error_code(async_account):
 
     assert module.error_code == 6
     assert "error_code" not in module.features
+    # The errored module and its bridged children are unreachable.
+    assert module.reachable is False
+    assert home.modules["12:34:56:00:01:ae"].reachable is False
 
     # Recovery: a subsequent healthy /homestatus update (the module is reported
     # in home.modules again) must clear the stale error code back to None.
@@ -800,3 +803,34 @@ async def test_set_selected_schedule_invalid_id(async_auth):
 
     assert home.schedules["sched-a"].selected is True
     assert home.schedules["sched-b"].selected is False
+
+
+async def test_async_home_module_reachable_feature(async_home):
+    """The private reachability attribute stays out of the public feature set."""
+    module = async_home.modules["12:34:56:00:01:ae"]
+    assert "reachable" in module.features
+    assert "_reachable" not in module.features
+
+
+async def test_async_home_module_reachable_absent_key_preserved(async_account):
+    """An absent `reachable` key keeps the previous value instead of forcing False."""
+    home_id = "91763b24c43d3e344f424e8b"
+    await async_account.async_update_status(home_id)
+    home = async_account.homes[home_id]
+
+    module_id = "12:34:56:00:01:01:01:b6"
+    module = home.modules[module_id]
+    assert module.reachable is True
+
+    homestatus = json.loads(load_fixture("homestatus_91763b24c43d3e344f424e8b.json"))
+    for raw_module in homestatus["body"]["home"]["modules"]:
+        if raw_module["id"] == module_id:
+            del raw_module["reachable"]
+
+    with patch(
+        "pyatmo.auth.AbstractAsyncAuth.async_post_api_request",
+        AsyncMock(return_value=MockResponse(homestatus, 200)),
+    ):
+        await async_account.async_update_status(home_id)
+
+    assert module.reachable is True

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -1,7 +1,11 @@
 """Define tests for switch module."""
 
+import json
+from unittest.mock import AsyncMock, patch
+
 from pyatmo import DeviceType
 from pyatmo.modules.device_types import DeviceCategory
+from tests.common import MockResponse, load_fixture
 
 
 async def test_async_switch_NLP(async_home):
@@ -51,11 +55,105 @@ async def test_async_switch_NLIS(async_home):
     assert module_id in async_home.modules
     module = async_home.modules[module_id]
     assert module.device_category is None
+    assert module.reachable is True
     module_id = "12:34:56:00:01:01:01:b6#1"
     assert module_id in async_home.modules
     module = async_home.modules[module_id]
     assert module.device_category == DeviceCategory.switch
+    # The API reports `reachable` only on the parent entry, so the gangs
+    # inherit it. See home-assistant/core#178403.
+    assert module.reachable is True
     module_id = "12:34:56:00:01:01:01:b6#2"
     assert module_id in async_home.modules
     module = async_home.modules[module_id]
     assert module.device_category == DeviceCategory.switch
+    assert module.reachable is True
+
+
+async def test_async_switch_NLIS_follows_parent_unreachable(async_account):
+    """NLIS gangs report unreachable once the parent module does."""
+    home_id = "91763b24c43d3e344f424e8b"
+    await async_account.async_update_status(home_id)
+    home = async_account.homes[home_id]
+
+    parent_id = "12:34:56:00:01:01:01:b6"
+    assert home.modules[f"{parent_id}#1"].reachable is True
+
+    homestatus = json.loads(load_fixture("homestatus_91763b24c43d3e344f424e8b.json"))
+    for raw_module in homestatus["body"]["home"]["modules"]:
+        if raw_module["id"] == parent_id:
+            raw_module["reachable"] = False
+
+    with patch(
+        "pyatmo.auth.AbstractAsyncAuth.async_post_api_request",
+        AsyncMock(return_value=MockResponse(homestatus, 200)),
+    ):
+        await async_account.async_update_status(home_id)
+
+    assert home.modules[parent_id].reachable is False
+    assert home.modules[f"{parent_id}#1"].reachable is False
+    assert home.modules[f"{parent_id}#2"].reachable is False
+
+
+async def test_async_switch_NLIS_reachable_again_after_bridge_error(
+    async_account_multi,
+):
+    """NLIS gangs recover once their bridge stops being reported in errors[].
+
+    The Legrand gateway of the multi home lists the `#`-suffixed gangs in
+    `modules_bridged`, and the gangs themselves never report `reachable`. An
+    error on the bridge must therefore not pin them unreachable for good.
+    See home-assistant/core#178403.
+    """
+    home_id = "aaaaaaaaaaabbbbbbbbbbccc"
+    bridge_id = "aa:aa:aa:aa:aa:aa"
+    parent_id = "98:76:54:32:10:00:00:24"
+    gang_ids = [f"{parent_id}#1", f"{parent_id}#2"]
+    home = async_account_multi.homes[home_id]
+    # The gangs are bridged children of the gateway, not only of their parent.
+    assert set(gang_ids) <= set(home.modules[bridge_id].modules)
+
+    # The gangs report their own state, but never `reachable`.
+    gang_status = [
+        {"id": gang_id, "type": "NLIS", "on": True, "power": 0} for gang_id in gang_ids
+    ]
+    healthy = {
+        "status": "ok",
+        "body": {
+            "home": {
+                "id": home_id,
+                "modules": [
+                    {"id": bridge_id, "type": "NLG", "reachable": True},
+                    {"id": parent_id, "type": "NLIS", "reachable": True},
+                    *gang_status,
+                ],
+            },
+        },
+    }
+    outage = {
+        "status": "ok",
+        "body": {
+            "home": {"id": home_id, "modules": gang_status},
+            "errors": [{"code": 3, "id": bridge_id}],
+        },
+    }
+
+    async def poll(payload):
+        with patch(
+            "pyatmo.auth.AbstractAsyncAuth.async_post_api_request",
+            AsyncMock(return_value=MockResponse(payload, 200)),
+        ):
+            await async_account_multi.async_update_status(home_id)
+
+    await poll(healthy)
+    assert [home.modules[gang_id].reachable for gang_id in gang_ids] == [True, True]
+
+    await poll(outage)
+    assert home.modules[bridge_id].reachable is False
+    assert home.modules[parent_id].reachable is False
+    assert [home.modules[gang_id].reachable for gang_id in gang_ids] == [False, False]
+
+    await poll(healthy)
+    assert home.modules[bridge_id].reachable is True
+    assert home.modules[parent_id].reachable is True
+    assert [home.modules[gang_id].reachable for gang_id in gang_ids] == [True, True]


### PR DESCRIPTION
## Summary by Sourcery

Adjust module reachability handling and add tests to ensure sub-modules inherit and preserve reachability correctly.

Bug Fixes:
- Ensure `#`-suffixed sub-modules resolve their `reachable` state from the parent module, preventing NLIS gangs from being incorrectly reported unreachable.
- Preserve previous `reachable` values when the key is absent from `/homestatus` payloads to avoid pinning modules and their bridged children unreachable and overwriting their readings.

Enhancements:
- Make `Module.reachable` a read-only property backed by a private `_reachable` attribute and introduce `Module.mark_unreachable()` for cascading reachability to bridged children while skipping sub-modules.
- Expose `reachable` as a public feature while keeping the backing `_reachable` attribute internal in the feature set.

Documentation:
- Document the new `Module.reachable` property semantics and the fix for sub-module reachability in the changelog.

Tests:
- Extend switch and home tests to cover sub-module reachability inheritance, error recovery, and behavior when `reachable` is absent or changes with bridge outages.