### PR TITLE
ci: pypi trusted publishing

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -9,27 +9,48 @@ permissions:
   contents: read
 
 jobs:
-  build-n-publish:
-    name: Build and publish 📦 to PyPI
+  build:
+    name: Build distribution 📦
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
     steps:
       - uses: actions/checkout@v7
         with:
+          # setuptools_scm derives the version from the tag; needs full history.
           fetch-depth: 0
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
 
-      - name: Install the project
-        run: uv sync --locked --all-extras --dev
-
       - name: Build a binary wheel and a source tarball
-        run: uv run python -m build .
+        run: uv build
+
+      - name: Store the distribution packages
+        uses: actions/upload-artifact@v5
+        with:
+          name: python-package-distributions
+          path: dist/
+
+  publish:
+    name: Publish 📦 to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/pyatmo
+    permissions:
+      # Trusted Publishing: mint the OIDC token PyPI exchanges for an upload
+      # token. Also what lets the action attach PEP 740 attestations.
+      id-token: write
+    steps:
+      - name: Download the distribution packages
+        uses: actions/download-artifact@v5
+        with:
+          name: python-package-distributions
+          path: dist/
 
       - name: Publish 📦 to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          password: ${{ secrets.pypi_prod_token }}
           skip-existing: true


### PR DESCRIPTION
## Summary by Sourcery

Set up a two-stage PyPI release workflow that builds distributions once and reuses them for trusted publishing with PyPI via OIDC.

Build:
- Split the publish-to-pypi workflow into separate build and publish jobs, persisting build artifacts between them.
- Switch the build step to use `uv build` and ensure full git history is available for versioning.
- Configure PyPI publishing to rely on GitHub OIDC (trusted publishing) instead of a stored PyPI API token.