### PR TITLE
Release v9.9.0

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -36,6 +36,25 @@ jobs:
           ref: development
           fetch-depth: 0
 
+      - name: Ensure master is an ancestor of development
+        run: |
+          set -euo pipefail
+          # A squashed mergeback leaves master unreachable from development. That
+          # pins this PR's merge base before the previous release, so both sides
+          # insert a section at the same [unreleased] anchor and CHANGELOG.md
+          # conflicts every time. It also strands the release tags, so
+          # setuptools_scm versions development builds from a stale tag.
+          #
+          # checkout above uses fetch-depth: 0, which already fetches every
+          # branch; the explicit fetch keeps this step correct on its own. The
+          # refspec is spelled out because a bare `git fetch origin master` only
+          # updates refs/remotes/origin/master opportunistically, when a
+          # configured remote.origin.fetch happens to match -- otherwise it
+          # writes FETCH_HEAD alone and the check below dies on an unresolvable
+          # ref, blocking the release for the wrong reason.
+          git fetch --no-tags origin '+refs/heads/master:refs/remotes/origin/master'
+          python3 scripts/release.py --check-ancestry origin/master HEAD
+
       - name: Ensure CI is green on the development head
         env:
           GH_TOKEN: ${{ github.token }}
@@ -85,8 +104,15 @@ jobs:
           git switch -c "${branch}"
           git commit -am "chore(release): v${VERSION}"
           git push --force-with-lease origin "${branch}"
+          instructions="$(cat <<'EOF'
+          **Merge this PR with "Create a merge commit"** -- not "Squash and merge",
+          not "Rebase and merge" -- so `master` stays reachable from `development`
+          for the mergeback that follows.
+          EOF
+          )"
+          printf -v body '%s\n\n%s' "${instructions}" "${NOTES}"
           gh pr create \
             --base master \
             --head "${branch}" \
             --title "Release v${VERSION}" \
-            --body "${NOTES}"
+            --body "${body}"

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -71,12 +71,24 @@ jobs:
           branch="mergeback/v${VERSION}"
           git switch -c "${branch}" master
           git push --force-with-lease origin "${branch}"
+          body="$(cat <<'EOF'
+          Return the release commit and the reset `[unreleased]` scaffold to development.
+
+          **Pick "Create a merge commit" from the merge dropdown -- not "Squash and
+          merge", not "Rebase and merge".** Either of those leaves `master` off
+          `development`'s history, which makes the next release PR conflict in
+          `CHANGELOG.md` and makes `setuptools_scm` version development builds from a
+          stale tag. `release-prepare.yml` refuses to cut a release while that is true.
+          EOF
+          )"
           url="$(gh pr create \
             --base development \
             --head "${branch}" \
             --title "Mergeback v${VERSION}" \
-            --body "Return release commit and reset \`[unreleased]\` to development.")"
-          # Best-effort: auto-merge needs repo auto-merge + required checks; if
-          # unavailable the PR stays open for a manual merge.
+            --body "${body}")"
+          # --merge pins the method to a merge commit server-side and --auto waits
+          # for the required approval, so no human picks a merge method. Needs
+          # "Allow auto-merge" enabled on the repository; if it is off the PR stays
+          # open and must be merged manually AS A MERGE COMMIT.
           gh pr merge "${url}" --auto --merge \
-            || echo "::notice::auto-merge unavailable; merge ${url} manually"
+            || echo "::warning::auto-merge unavailable; merge ${url} manually as a merge commit"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Added
+
+- Report which webhook URLs are registered, so a registration that was dropped
+  or overwritten can be detected. A banned webhook is still listed, so this
+  proves a webhook is registered - not that anything reaches it
+- Record when the last webhook payload arrived, including payloads the library
+  cannot classify
+- `Home.has_status` tells you up front whether a home can be polled, so the ones
+  Netatmo refuses need never be called
+
+### Changed
+
+- A home Netatmo permanently refuses now fails in its own distinct way, so it
+  can be dropped rather than retried forever. Existing error handling still
+  catches it
+- Errors now carry the status and error code Netatmo sent back, so one kind of
+  failure can be told apart from another
+- Error logs and messages now name the home they came from
+- Webhooks are managed through Netatmo's new endpoints
+
+### Fixed
+
+- Error messages for HTTP 409 and 429 name the status instead of leaving a
+  blank where it should be
+- Webhook URLs are redacted in logs. They are secrets, and debug logs end up in
+  bug reports
+- Devices belonging to no known home are named in the log
+- Stop searching every home for a device that already said which home it is in
+
 ## [9.8.0] - 2026-08-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [9.9.0] - 2026-08-18
+
 ### Added
 
 - Report which webhook URLs are registered, so a registration that was dropped
@@ -605,6 +607,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix crash when station name is not contained in the backend data
 
+[9.9.0]: https://github.com/jabesq-org/pyatmo/compare/v9.8.0...v9.9.0
 [9.8.0]: https://github.com/jabesq-org/pyatmo/compare/v9.7.0...v9.8.0
 [9.7.0]: https://github.com/jabesq-org/pyatmo/compare/v9.6.0...v9.7.0
 [9.6.0]: https://github.com/jabesq-org/pyatmo/compare/v9.5.0...v9.6.0

--- a/README.md
+++ b/README.md
@@ -70,3 +70,7 @@ Another way to run the tests is by using `tox`. This runs the tests against the 
 or by specifying a python version
 
     tox -e py310
+
+## Releasing
+
+Maintainers: see [docs/release-process.md](docs/release-process.md).

--- a/docs/home-assistant-webhook-integration.md
+++ b/docs/home-assistant-webhook-integration.md
@@ -1,0 +1,428 @@
+# Consuming pyatmo webhook processing from Home Assistant
+
+Implementation guide for wiring `pyatmo`'s webhook support into the Home Assistant Netatmo
+integration.
+
+Both halves of this document are **verified against source**: the pyatmo contract was measured
+against the implementation, and the Home Assistant details were read from
+`homeassistant/components/netatmo/` (HA `b955e776e78`, which pins `pyatmo==9.5.0`).
+
+---
+
+## 0. What the integration does today
+
+Worth establishing first, because it is not what the pyatmo-side design assumes.
+
+**The integration does not touch pyatmo model objects from webhooks.** `async_handle_webhook`
+(`webhook.py:50`) decodes the payload and fans it out over dispatcher signals
+`signal-netatmo-webhook-{event_type}`. Each platform then parses the **raw payload** and writes HA
+entity attributes directly:
+
+- `climate.py:247 handle_event` — reads `data["home"]["rooms"][…]["therm_setpoint_mode"]` and sets
+  `_attr_hvac_mode`, `_attr_preset_mode`, `_attr_target_temperature`, then `async_write_ha_state()`
+- `light.py:106 handle_event` — sets `_attr_is_on` from `data["sub_type"]`
+- `camera.py:142 handle_event` — same shape for monitoring/streaming state
+
+Polling is separate: `NetatmoDataHandler.async_fetch_data` (`coordinator.py:249`) calls the
+`AsyncAccount.async_update_*` method for a publisher, which mutates the pyatmo model, then
+`_notify_subscribers` invokes each entity's `async_update_callback()`, which **re-derives `_attr_*`
+from the pyatmo object** (`entity.py` — entities hold `self.device`, typed `Room`/`Module`).
+
+Two consequences:
+
+1. **`NetatmoDataHandler` is not a `DataUpdateCoordinator`.** It is a bespoke class built on
+   `async_track_time_interval` plus a `deque` queue of `NetatmoPublisher` entries. There is no
+   `coordinator.data`, no `async_set_updated_data`, and no `async_request_refresh`.
+2. **A lost-update race already exists, independent of pyatmo.** A poll that fetched *before* a
+   webhook arrived but completes *after* it calls `_notify_subscribers`, which re-derives `_attr_*`
+   from a pyatmo model that never saw the webhook — reverting the optimistic value.
+
+Adopting `process_webhook` **narrows** that existing race rather than introducing one: the merge lands
+in the pyatmo model, so re-derivation reproduces the webhook state instead of discarding it. The
+remaining window is only until the next *fetch*, not the next *notify*.
+
+---
+
+## 1. API surface
+
+```python
+from pyatmo import LifecycleStatus, WebhookEvent, WebhookKind, WebhookResult
+
+result: WebhookResult = await data_handler.account.process_webhook(payload)
+```
+
+Requires a `pyatmo` bump — the manifest currently pins `9.5.0`.
+
+### `WebhookResult`
+
+| Field | Type | Meaning |
+|---|---|---|
+| `home_id` | `str \| None` | Resolved from top-level `home_id` or nested `home.id` |
+| `event_type` | `str \| None` | `None` if absent or wrongly typed |
+| `push_type` | `str \| None` | |
+| `kind` | `WebhookKind` | Routing category |
+| `touched_ids` | `list[str]` | Ids the merge actually wrote (empty if nothing changed) |
+| `events` | `list[WebhookEvent]` | Only for `kind is EVENT`; currently 0 or 1 entry |
+| `needs_refresh` | `bool` | pyatmo could not merge — refetch to learn the new state |
+| `lifecycle` | `LifecycleStatus \| None` | Only for `kind is LIFECYCLE` |
+
+### `WebhookKind` → action
+
+Matrix produced by running each payload shape, not read off the code:
+
+| `kind` | Trigger | `needs_refresh` | `events` | Your action |
+|---|---|---|---|---|
+| `STATE` | `set_point`, `cancel_set_point`, `therm_mode`, `on`, `off`, `light_mode` | `False` | 0 | Model already merged — notify subscribers |
+| `EVENT` | 36 types (`person`, `movement`, `smoke`, `siren_sounding`, …) | `False` | 1 | Fire the bus event; no model change |
+| `TOPOLOGY_DIRTY` | `schedule` | **`True`** | 0 | `async_force_update(...)` |
+| `LIFECYCLE` | `webhook_activation`, `webhook_deactivation`, `*-connection` | see below | 0 | Track webhook state; force update on reconnect |
+| `UNKNOWN` | anything unrecognised or malformed | `False` | 0 | Debug-log and drop |
+
+| `push_type` | `lifecycle` | `needs_refresh` |
+|---|---|---|
+| `webhook_activation` | `ACTIVATION` | `False` |
+| `webhook_deactivation` | `DEACTIVATION` | `False` |
+| `NACamera-connection`, `NOC-connection`, `NDB-connection` | `CONNECTION` | **`True`** |
+
+This maps **1:1 onto `NetatmoDataHandler.handle_event`** (`coordinator.py:235`), which already sets
+`self._webhook = True/False` on activation/deactivation and calls `async_force_update(ACCOUNT)` for
+`CAMERA_CONNECTION_WEBHOOKS`. `needs_refresh` is exactly that existing decision, expressed as data.
+
+### `WebhookEvent`
+
+`event_type`, `push_type`, `home_id`, `module_id`, `camera_id`, `device_id`, `person_ids`, `sub_type`,
+`snapshot_url`, `message`, `raw`.
+
+Every scalar is `str | None` and guaranteed to be a string or `None` — a wrongly-typed value from
+Netatmo is coerced to `None` rather than passed through. `person_ids` contains only strings. `raw` is
+the original payload dict **by reference**, as an escape hatch for unmodelled fields.
+
+`WebhookEvent` and `WebhookResult` are `frozen=True` but **not hashable** (`person_ids`, `raw`,
+`touched_ids`, `events` are mutable, so `hash()` raises `TypeError`). Compare by value; never use them
+as dict keys or set members.
+
+---
+
+## 2. The hard constraint: answer Netatmo immediately
+
+Netatmo deactivates an endpoint that does not respond promptly.
+
+The current handler already respects this — dispatcher sends are synchronous callbacks and it awaits
+no network I/O. **Keep it that way.** `process_webhook` is safe here: it performs no I/O and never
+suspends, enforced upstream by `test_process_webhook_never_suspends`, so it cannot silently regress.
+
+Do **not**, before returning:
+
+- `await data_handler.async_fetch_data(...)` or any `account.async_update_*` call. `pyatmo.auth`
+  retries HTTP 429 with backoff capped at 60 s; one rate-limited fetch can stall past Netatmo's
+  tolerance and cost the webhook.
+- Acquire a lock that a poll can hold across an HTTP request, for the same reason.
+
+`async_force_update` is safe: it is a `@callback` that only sets `next_scan = time()` and rotates the
+queue (`coordinator.py:229`). It does not perform I/O.
+
+---
+
+## 3. Suggested handler shape
+
+```python
+from pyatmo import LifecycleStatus, WebhookKind
+
+from .coordinator import ACCOUNT, HOME
+
+
+async def async_handle_webhook(
+    hass: HomeAssistant, webhook_id: str, request: Request
+) -> None:
+    """Handle webhook callback. Must return promptly."""
+    try:
+        data = await request.json()
+    except ValueError as err:
+        _LOGGER.error("Error in data: %s", err)
+        return
+
+    entry = next(
+        (
+            entry
+            for entry in hass.config_entries.async_loaded_entries(DOMAIN)
+            if entry.data.get(CONF_WEBHOOK_ID) == webhook_id
+        ),
+        None,
+    )
+    if entry is None:
+        return
+    data_handler = entry.runtime_data
+
+    # No I/O, never suspends: safe on the response path.
+    result = await data_handler.account.process_webhook(data)
+
+    if result.kind is WebhookKind.LIFECYCLE:
+        data_handler.set_webhook_state(result.lifecycle)      # new helper
+
+    if result.kind is WebhookKind.EVENT:
+        for event in result.events:
+            async_send_event(data_handler, event, data)
+
+    if result.needs_refresh:
+        data_handler.async_force_update(ACCOUNT)
+    elif result.touched_ids and result.home_id:
+        # pyatmo merged into the model; make entities re-derive from it.
+        data_handler.notify_home_subscribers(result.home_id)  # new helper
+```
+
+Two small helpers on `NetatmoDataHandler`:
+
+```python
+    @callback
+    def set_webhook_state(self, lifecycle: LifecycleStatus | None) -> None:
+        """Track webhook availability from a LIFECYCLE result."""
+        if lifecycle is LifecycleStatus.ACTIVATION:
+            self._webhook = True
+        elif lifecycle is LifecycleStatus.DEACTIVATION:
+            self._webhook = False
+        elif lifecycle is LifecycleStatus.CONNECTION:
+            self.async_force_update(ACCOUNT)
+
+    @callback
+    def notify_home_subscribers(self, home_id: str) -> None:
+        """Re-render entities for a home after an in-model merge."""
+        signal_name = f"{HOME}-{home_id}"
+        if signal_name in self.publisher:
+            self._notify_subscribers(signal_name)
+```
+
+`f"{HOME}-{home_id}"` is the signal name convention entities already use — see
+`climate.py:206`, `self._signal_name = f"{HOME}-{self.home.entity_id}"`.
+
+---
+
+## 4. What this replaces
+
+The per-platform `handle_event` methods currently re-parse the raw payload to compute entity state.
+With `process_webhook`, the model is already correct, so those methods collapse into the existing
+`async_update_callback()` path.
+
+| Today | With `process_webhook` |
+|---|---|
+| `climate.py:247-330` parses `home.rooms[].therm_setpoint_*` and sets three `_attr_*` fields | pyatmo merges the setpoint fields; `async_update_callback()` re-derives them |
+| `light.py:106` sets `_attr_is_on` from `data["sub_type"]` | pyatmo sets `module.floodlight`; re-derive |
+| `camera.py:142` sets monitoring/streaming state | pyatmo sets `module.monitoring`; re-derive |
+
+Migrate one platform at a time — nothing forces a single cut-over, since dispatcher signals and
+`process_webhook` can coexist during the transition.
+
+**Keep the `schedule` handling in `climate.py:254-275` as it is.** It reads
+`data_handler.schedules[...]`, which is integration state pyatmo knows nothing about. pyatmo only
+reports `TOPOLOGY_DIRTY` / `needs_refresh` for that event.
+
+**Keep the bus event.** `NETATMO_EVENT` with `{"type", "data", ATTR_DEVICE_ID}` is public API for user
+automations and `device_trigger.py`. Source its fields from `WebhookEvent` if convenient, but keep
+`"data"` as the raw payload — `event.raw` is exactly that dict, so nothing changes for consumers.
+
+---
+
+## 5. The residual staleness window
+
+For `kind is STATE`, pyatmo merges rather than refetching — deliberate, given how hard the integration
+already works to stay under the rate limit (`_rate_limit`, `poll_count`, `next_scan += 60` in
+`coordinator.py:222`).
+
+A poll that fetched **before** the webhook and completes after it will still overwrite the merge, then
+`_notify_subscribers` re-renders the older values. Reproduced upstream: a room at
+`therm_setpoint_mode == "away"` / `12` merges to `"manual"` / `25`, then a poll suspended mid-flight
+completes and reverts it.
+
+Self-healing — Netatmo is authoritative and already applied the change, so the next poll shows the
+truth. Symptom is a setpoint that flicks back for up to one `HOME` interval (300 s ÷ interval factor).
+
+Does **not** help:
+
+- `async_set_updated_data` — **does not exist here**; `NetatmoDataHandler` is not a
+  `DataUpdateCoordinator`. Even in an integration that had it, it cannot cancel a fetch already in
+  flight, and these entities read pyatmo objects rather than `coordinator.data`.
+- A lock inside pyatmo — it would have to wrap the fetch, putting the 429 backoff on the response
+  path (§2).
+
+**Does** help, and only you can do it since you own the handler: keep the response immediate, but
+order the *merge* after any in-flight fetch. An `asyncio.Lock` held by both `async_fetch_data` and a
+post-response merge task achieves it; because the lock is taken after the handler has returned,
+blocking on it is harmless.
+
+Given the failure is self-healing and the window already exists today, accepting it is defensible.
+Adopting `process_webhook` makes it strictly better than the status quo either way.
+
+---
+
+## 6. Mapping `touched_ids`
+
+`touched_ids` holds only ids pyatmo actually wrote — empty when the payload resolved to no known
+entity, or when every value was rejected. The **namespace depends on `event_type`**:
+
+| `event_type` | ids are |
+|---|---|
+| `set_point`, `cancel_set_point` | room ids |
+| `therm_mode` | the home id |
+| `on`, `off`, `light_mode` | module ids |
+| any `EVENT` kind | module / camera / device ids |
+
+For this integration the simplest use is the one in §3 — ignore the individual ids and notify the
+`f"{HOME}-{home_id}"` publisher, since `async_update_callback()` is cheap and already re-derives
+everything from the model. Per-id targeting is only worth it if that proves too coarse.
+
+Ids do not collide across namespaces (44 room, 194 module, 7 home ids across pyatmo's fixtures, zero
+overlap), but branch on `event_type` rather than guessing from an id's shape — some module ids are
+numeric, not MAC-formatted.
+
+An empty `touched_ids` with `kind is STATE` is normal, not an error.
+
+---
+
+## 7. Cleanups this enables
+
+- **`SUBEVENT_TYPE_MAP` is dead code.** `webhook.py:44` maps `"outdoor"` and `"therm_mode"` to `""`,
+  so `data.get(SUBEVENT_TYPE_MAP[event_type], [])` is always `data.get("", [])` → `[]`, and the
+  sub-event loop at `webhook.py:79` never executes. Confirmed by evaluating it. Presumably the value
+  was once a real key. Delete it or restore the intended key.
+- **Duplicated constants.** `CAMERA_CONNECTION_WEBHOOKS` (`const.py:214`) and the `EVENT_TYPE_*` /
+  `WEBHOOK_*` families now exist upstream. Importing from pyatmo removes the risk of the two lists
+  drifting when Netatmo adds a push type.
+- **Classification logic.** pyatmo's `classify()` covers 6 STATE types, 36 EVENT types, `schedule`,
+  and the three `*-connection` push types, so the per-platform `push_type`/`event_type` matching can
+  be replaced by a `kind` check.
+
+## 8. Gotchas
+
+- **`camera_id` vs `device_id`.** pyatmo resolves a camera as `camera_id or device_id`. Real payloads
+  have them equal; do not rely on both being present. Note `camera.py:152` already returns early when
+  `camera_id` is missing — pyatmo behaves the same way, yielding empty `touched_ids`.
+- **`connection` is LIFECYCLE, `disconnection` is EVENT.** A reconnect sets `needs_refresh=True`
+  because state may have changed while the camera was away; a disconnection is a plain event. The
+  asymmetry is intentional and matches what `handle_event` does today.
+- **`UNKNOWN` is not a failure.** Netatmo adds push types; unrecognised ones surface as `UNKNOWN` so
+  the integration keeps working. Debug-log, do not warn per push.
+- **Malformed input never raises.** A wrongly-typed scalar is treated as absent and logged at pyatmo's
+  DEBUG level. If a payload seems ignored, enable `pyatmo` debug logging and look for
+  `Discarding non-string value` / `Discarding non-numeric value`.
+- **`raw` is shared.** `event.raw` is the same dict you passed in. Do not mutate it if you keep the
+  event.
+- **`async_force_update` needs a registered publisher.** It indexes `self.publisher[signal_name]` and
+  will `KeyError` if nothing has subscribed to that signal yet. Guard as
+  `notify_home_subscribers` does above.
+
+## 9. Registering a webhook, and telling whether it works
+
+Netatmo suspends delivery to an endpoint that answers slowly, and never tells you through the
+API. A suspended endpoint still accepts `addwebhook` with a `200` and still appears in the
+registration list, so neither registration success nor a listing proves anything is delivered.
+
+**Registration is deduplicated on the URL value, not on the call** — measured against a live
+account on 2026-08-14 and since confirmed by Netatmo support, who state that calling
+`addwebhook` for an already registered URL does not trigger another activation:
+
+| call | result |
+|---|---|
+| `addwebhook` with the URL already registered | `{"status":"ok"}`, no activation push |
+| `addwebhook` with a **different** URL | registration replaced silently, `webhook_activation` follows, no `dropwebhook` involved |
+| `dropwebhook` then `addwebhook` | `webhook_activation` follows |
+
+**An activation is not prompt.** One measured run took ~31 s; Netatmo state that activations
+currently still go through their **legacy delivery system** and were delayed by one to two
+minutes in their own tests. Budget for tens of seconds to a couple of minutes, and never for a
+fixed figure.
+
+**Do not build a liveness probe on activations.** Eliciting one means pointing the webhook
+somewhere else and back, which leaves a window in which no working webhook is registered, and a
+failed re-add leaves the consumer with none at all — and the answer arrives minutes later, if
+the URL changed at all.
+
+What to use instead:
+
+- `auth.async_list_webhooks()` reports which URLs are currently registered. It detects a
+  webhook that was dropped, or overwritten by another client sharing the credentials. It does
+  **not** reveal a suspension or a ban.
+- `account.last_webhook_at` is set on every processed payload, including ones this library
+  classifies as `UNKNOWN`. Delivery of anything proves the path works.
+
+### Bans and suspensions
+
+**There is no API to check ban status.** Only the developer portal at
+<https://dev.netatmo.com/apps/> shows it. Netatmo describe two mechanisms:
+
+- The **legacy ban is application-level** — it affects every webhook of the application, mainly
+  topology and camera events. It triggers after **five consecutive delivery failures** and
+  clears after **24 hours**, or immediately when unbanned by hand in the portal.
+- The **new system uses a per-webhook-URL circuit breaker**, which can suspend deliveries for up
+  to **10 minutes**.
+
+For a consumer that means silence shorter than ~10 minutes may be nothing worse than a
+circuit-breaker window, while silence lasting far longer points at the 24-hour application ban.
+Neither is observable through the API, which is exactly why `async_list_webhooks` is documented
+as proving registration and not delivery.
+
+### The `webhooks/v1` endpoints
+
+They exist alongside the legacy `api/addwebhook` and `api/dropwebhook`, and were measured on
+2026-08-15:
+
+| call | result |
+|---|---|
+| `GET webhooks/v1/` | `200`, `{"status", "time_server", "body": [{"url": …}]}` — entries carry **only a url, no id** |
+| `POST webhooks/v1` with `{"url": …}` | `200` |
+| `POST webhooks/v1` with one already registered | `409`, `{"code":"WH009","message":"webhook limit reached for this application"}` |
+| `DELETE webhooks/v1`, no body | `200`, the application's webhook is cleared |
+
+The limit is **one webhook per application**, which is what the `409` means.
+
+Netatmo state that the webhook management endpoints **work for both delivery systems**: how a
+webhook is registered says nothing about which system delivers it. pyatmo therefore deliberately
+keeps writing through the legacy `api/addwebhook` / `api/dropwebhook` and only *reads* through
+`GET webhooks/v1/`. Writing through v1 would mean delete-then-post, because of the
+one-webhook limit — opening a window with no registration at all — and would buy no delivery
+benefit in exchange.
+
+### Failure shapes worth recognising
+
+**`addwebhook` validates the host at registration time.** A URL whose host does not resolve is
+rejected with `400` and `{"error":{"code":21,"message":"Invalid url parameter"}}`. An
+unreachable endpoint therefore cannot be registered at all, which is why a webhook that stops
+working can only be produced by registering a working URL and then breaking it. Code 21 is a
+generic invalid-parameter code — `/homestatus` answers a rejected home id with the same pair —
+so this surfaces as a plain `ApiError` carrying `status == 400` and `code == 21`, never as
+`InvalidHomeError`.
+
+**Error codes are not always integers.** The `api/*` endpoints answer with integers (11, 21,
+26), `webhooks/v1` with strings such as `"WH009"`. `ApiError.code` is typed `int | str | None`
+and passes through whatever arrived; compare against the shape you expect.
+
+**A request stopped by Netatmo's edge/WAF has no JSON at all.** The body is HTML, so it surfaces
+as an `ApiError` carrying a status and `code is None`.
+
+**Space registration calls out.** Four `addwebhook` calls in quick succession returned
+`{"error":{"code":27,"message":"Service temporarily unavailable"}}`, which looks like a
+per-endpoint rate limit rather than a real outage.
+
+## 10. Homes that cannot be polled
+
+`/homesdata` lists homes that `/homestatus` refuses, in two different ways. Measured
+against a live account on 2026-08-13, three of six homes could not be polled: one
+returned `{"error":{"code":21,"message":"Invalid home_id"}}`, and two answered `200`
+with no `body` at all. Both are reproducible on every poll.
+
+Two ways to avoid spending calls on one:
+
+- `Home.has_status` is `False` when a home carries no modules, which is what the
+  unpollable homes have in common. Check it before scheduling a poll. Device
+  category plays no part: `/homestatus` does report weather modules, so excluding
+  them would hide a home that polls fine.
+- `InvalidHomeError` is raised by `async_update_status` when the API rejects the home
+  id it sent. It is deterministic -- the same id fails every time -- so stop polling
+  that home rather than retrying it. It subclasses `ApiError`, so existing handlers
+  still catch it. The underlying error code is generic (see §9), so only this call
+  translates it; every other `ApiError` means something else.
+
+`NoDeviceError`, raised for the empty-body case, is deliberately **not** a signal to
+stop. It also covers an empty `homes` list and empty weather or air-care data, where
+one odd response must not disable a working publisher.
+
+The library deliberately does not skip the call itself. It has no scheduler, and a
+silent no-op would hide the situation from every caller.

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -1,0 +1,118 @@
+# Release process
+
+Releases are cut from `development` into `master` by two GitHub Actions
+workflows. Nothing is published by hand.
+
+## Branch topology
+
+    development ──┬─────────────────────────────┬──── (ongoing work)
+                  │                             │
+                  │ release/vX.Y.Z              │ mergeback/vX.Y.Z
+                  ▼                             ▲
+    master ───────┴── merge commit, tagged vX.Y.Z ──┘
+
+- `development` is the integration branch. Feature PRs target it and are
+  **squashed**.
+- `master` only ever receives release merges. No hotfixes land on it directly.
+- Every release ends with a mergeback PR that returns the release commit to
+  `development`. That PR must be merged as a **merge commit** — never squashed,
+  never rebased. See [The merge-method rule](#the-merge-method-rule).
+
+## Cutting a release
+
+1. Land everything you want in the release on `development`, each PR adding its
+   entry under `## [unreleased]` in `CHANGELOG.md`.
+2. Run the **Release · prepare** workflow from the Actions tab, choosing
+   `patch`, `minor`, or `major`.
+
+   It refuses to proceed unless `master` is an ancestor of `development` and the
+   `Python package` workflow is green on the `development` head.
+
+   It then rewrites `CHANGELOG.md` via `scripts/release.py --bump`: `[unreleased]`
+   becomes `[X.Y.Z] - <date>`, a fresh empty `[unreleased]` goes on top, and a
+   compare link is added. It pushes `release/vX.Y.Z` and opens a PR into `master`.
+3. Review and merge the release PR. **Merge commit**, not squash.
+4. **Release · publish** then runs automatically: it tags the merge commit
+   `vX.Y.Z`, creates the GitHub Release from the changelog section, and opens the
+   mergeback PR into `development`.
+
+   The tag push triggers **Publish 📦 to PyPI** (`publish-to-pypi.yml`).
+5. Approve the mergeback PR. With *Allow auto-merge* enabled it merges itself as a
+   merge commit. If auto-merge is off, the workflow logs a warning and you must
+   merge it manually — **as a merge commit**.
+
+## The merge-method rule
+
+Feature PRs are squashed. **Mergeback PRs must not be** — and must not be
+rebase-merged either.
+
+Both a squash and a rebase produce commits with a single parent, so the release
+commits on `master` never become reachable from `development`. Two things then
+break:
+
+1. `merge-base(development, master)` stays pinned *before* the last release. The
+   next release PR therefore diffs across all accumulated release history, and
+   both sides insert a new section at the same `## [unreleased]` anchor — so
+   `CHANGELOG.md` conflicts, and the conflicted region grows every release.
+2. Release tags live only on `master`. `setuptools_scm` derives the version from
+   the nearest *reachable* tag, so builds off `development` get versioned from a
+   stale tag (at one point `v9.2.3-97-g…` while the real version was 9.8.0).
+
+`release-prepare.yml` gates on this, so drift blocks the *next* release rather
+than silently corrupting it.
+
+## Recovering from drift
+
+If **Release · prepare** fails with:
+
+```
+::error::origin/master is not an ancestor of HEAD. The last mergeback was squashed or rebased, ...
+```
+
+then a mergeback did not produce a merge commit. Check it:
+
+```bash
+git fetch origin
+python3 scripts/release.py --check-ancestry origin/master origin/development
+git describe --tags origin/development   # should report the latest release
+```
+
+Fix it by merging `master` into `development` with a real merge commit — via a PR,
+since `development` is protected. No history rewriting and no force pushes are
+needed. If a mergeback PR is still open, merging it with *Create a merge commit*
+is enough on its own.
+
+If `development` picked up new `## [unreleased]` entries after the squashed
+mergeback, this merge will conflict in `CHANGELOG.md` at the `## [unreleased]`
+anchor. Resolve it by keeping both sides: the released version section coming
+in from `master`, and the entries already on `development` staying under
+`## [unreleased]`.
+
+To confirm a mergeback really produced a merge commit, count its parents:
+
+```bash
+git rev-list --parents -n1 <mergeback-merge-sha> | wc -w
+```
+
+Three means a merge commit (the commit plus two parents). Two means it was
+squashed or rebased.
+
+## Local dry run
+
+`scripts/release.py` never tags or pushes. To preview what a release would do to
+the changelog:
+
+```bash
+uv run python scripts/release.py --bump minor --dry-run
+```
+
+Right after a release the `[unreleased]` section is an empty scaffold, so this
+reports `error: the [unreleased] section has no entries; nothing to release` and
+exits 1. That is the guard doing its job, not a broken script — the same guard
+stops **Release · prepare** from cutting an empty release.
+
+To print the notes for an already-released version:
+
+```bash
+uv run python scripts/release.py --notes 9.8.0
+```

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -12,6 +12,7 @@ or pushes -- that is done by the CI workflow (or a maintainer for a local run).
 Usage:
     release.py --bump {patch,minor,major} [--dry-run]
     release.py --notes X.Y.Z
+    release.py --check-ancestry ANCESTOR DESCENDANT
 """
 
 from __future__ import annotations
@@ -143,6 +144,40 @@ def _latest_tag() -> str:
     return tags[0]
 
 
+def _is_shallow() -> bool:
+    """Return whether the current repository is a shallow clone."""
+    out = subprocess.run(
+        ["git", "rev-parse", "--is-shallow-repository"],
+        check=False,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    return out == "true"
+
+
+def is_ancestor(ancestor: str, descendant: str) -> bool:
+    """Return whether ``ancestor`` is reachable from ``descendant``.
+
+    Raises ``ReleaseError`` when git cannot answer -- a bad ref, or a shallow
+    clone whose graft boundary hides the merge that would prove reachability.
+    """
+    result = subprocess.run(
+        ["git", "merge-base", "--is-ancestor", ancestor, descendant],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    # 0 = reachable, 1 = not reachable; anything else is a git failure (bad ref,
+    # not a repository) and must not be read as "not reachable".
+    if result.returncode not in (0, 1):
+        msg = f"git merge-base failed: {result.stderr.strip()}"
+        raise ReleaseError(msg)
+    if result.returncode == 1 and _is_shallow():
+        msg = "cannot determine ancestry in a shallow clone; fetch full history"
+        raise ReleaseError(msg)
+    return result.returncode == 0
+
+
 def finalize_changelog(
     text: str,
     version: str,
@@ -208,6 +243,22 @@ def _emit_output(version: str, notes: str) -> None:
         fh.write(f"notes<<{delimiter}\n{notes}\n{delimiter}\n")
 
 
+def _fail(msg: str) -> int:
+    """Report a fatal error on stderr and return the process exit code.
+
+    Emits a GitHub Actions annotation under CI and a plain message otherwise. A
+    workflow command must be one line, so newlines are percent-encoded -- git can
+    produce multi-line stderr (e.g. the "dubious ownership" hint), and without
+    this only its first line would reach the annotation.
+    """
+    if os.environ.get("GITHUB_ACTIONS"):
+        encoded = msg.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
+        print(f"::error::{encoded}", file=sys.stderr)
+    else:
+        print(f"error: {msg}", file=sys.stderr)
+    return 1
+
+
 def _cmd_bump(args: argparse.Namespace) -> int:
     text = CHANGELOG.read_text(encoding="utf-8")
     current = _latest_tag()
@@ -215,12 +266,7 @@ def _cmd_bump(args: argparse.Namespace) -> int:
     version = bump_version(current, args.bump)
     date = datetime.datetime.now(tz=datetime.UTC).strftime("%Y-%m-%d")
 
-    try:
-        new_text = finalize_changelog(text, version, date, prev)
-    except ReleaseError as err:
-        print(f"error: {err}", file=sys.stderr)
-        return 1
-
+    new_text = finalize_changelog(text, version, date, prev)
     notes = extract_notes(new_text, version)
 
     if args.dry_run:
@@ -243,6 +289,28 @@ def _cmd_notes(args: argparse.Namespace) -> int:
     return 0
 
 
+def _cmd_check_ancestry(args: argparse.Namespace) -> int:
+    """Fail unless ANCESTOR is reachable from DESCENDANT.
+
+    Guards a release against a squashed mergeback. A squash leaves ``master``
+    unreachable from ``development``, which pins the release PR's merge base
+    before the previous release: both sides then insert a section at the same
+    ``[unreleased]`` anchor and ``CHANGELOG.md`` conflicts every time. It also
+    strands the release tags, so setuptools_scm versions development builds from
+    a stale tag.
+    """
+    ancestor, descendant = args.check_ancestry
+    if is_ancestor(ancestor, descendant):
+        print(f"{ancestor} is an ancestor of {descendant}")
+        return 0
+    return _fail(
+        f"{ancestor} is not an ancestor of {descendant}. The last mergeback was "
+        f"squashed or rebased, or {ancestor} has commits that never came back. Merge "
+        f"{ancestor} into {descendant} with a real merge commit (not a squash or "
+        f"rebase) before releasing. See docs/release-process.md for recovery steps."
+    )
+
+
 def _print_diff(before: str, after: str) -> None:
     diff = difflib.unified_diff(
         before.splitlines(keepends=True),
@@ -255,10 +323,19 @@ def _print_diff(before: str, after: str) -> None:
 
 def main(argv: list[str] | None = None) -> int:
     """Parse arguments and dispatch to the requested subcommand."""
-    parser = argparse.ArgumentParser(description=__doc__)
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument("--bump", choices=_BUMP_PARTS, help="version part to bump")
     group.add_argument("--notes", metavar="X.Y.Z", help="print notes for a version")
+    group.add_argument(
+        "--check-ancestry",
+        nargs=2,
+        metavar=("ANCESTOR", "DESCENDANT"),
+        help="exit non-zero unless ANCESTOR is reachable from DESCENDANT",
+    )
     parser.add_argument(
         "--dry-run",
         action="store_true",
@@ -266,9 +343,22 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
 
-    if args.notes:
-        return _cmd_notes(args)
-    return _cmd_bump(args)
+    if args.dry_run and not args.bump:
+        parser.error("--dry-run only applies to --bump")
+
+    try:
+        if args.check_ancestry:
+            return _cmd_check_ancestry(args)
+        if args.notes:
+            return _cmd_notes(args)
+        if args.bump:
+            return _cmd_bump(args)
+    except ReleaseError as err:
+        return _fail(str(err))
+    # Unreachable while the argument group is required=True; parser.error() raises
+    # SystemExit, and the return only satisfies the "all paths return" check.
+    parser.error("no command given")
+    return 1
 
 
 if __name__ == "__main__":

--- a/src/pyatmo/account.py
+++ b/src/pyatmo/account.py
@@ -9,6 +9,7 @@ import warnings
 
 from pyatmo import modules
 from pyatmo.const import (
+    BAD_REQUEST_ERROR_CODE,
     GETEVENTS_ENDPOINT,
     GETHOMECOACHDATA_ENDPOINT,
     GETHOMESDATA_ENDPOINT,
@@ -16,10 +17,12 @@ from pyatmo.const import (
     GETPUBLIC_DATA_ENDPOINT,
     GETSTATIONDATA_ENDPOINT,
     HOME,
+    INVALID_HOME_ERROR_CODE,
     SETSTATE_ENDPOINT,
     RawData,
 )
 from pyatmo.enums import PressureUnit, UnitSystem, WindUnit
+from pyatmo.exceptions import ApiError, InvalidHomeError
 from pyatmo.helpers import extract_raw_data
 from pyatmo.home import Home
 from pyatmo.modules.module import Energy, MeasureInterval, Module
@@ -60,6 +63,7 @@ class AsyncAccount:
         self.favorite_stations: bool = favorite_stations
         self.public_weather_areas: dict[str, modules.PublicWeatherArea] = {}
         self.modules: dict[str, Module] = {}
+        self.last_webhook_at: float | None = None
 
     def __repr__(self) -> str:
         """Return the representation."""
@@ -139,14 +143,42 @@ class AsyncAccount:
         self.process_topology()
 
     async def async_update_status(self, home_id: str) -> None:
-        """Retrieve status data from /homestatus."""
+        """Retrieve status data from /homestatus.
+
+        Raises ``InvalidHomeError`` when the API refuses the home id. That
+        verdict can only be reached here: the API answers with the generic
+        invalid-parameter code 21, which other endpoints also use for their own
+        parameters, so it means "invalid home id" only because this call sent
+        one.
+        """
         if self._warn_if_disabled(home_id):
             return
-        resp: ClientResponse = await self.auth.async_post_api_request(
-            endpoint=GETHOMESTATUS_ENDPOINT,
-            params={"home_id": home_id},
-        )
-        raw_data: RawData = extract_raw_data(await resp.json(), HOME)
+        try:
+            resp: ClientResponse = await self.auth.async_post_api_request(
+                endpoint=GETHOMESTATUS_ENDPOINT,
+                params={"home_id": home_id},
+            )
+        except ApiError as exc:
+            # InvalidHomeError is itself an ApiError. It is let through rather
+            # than wrapped in a second one -- reachable when a consumer's
+            # AbstractAsyncAuth subclass raises it directly.
+            if isinstance(exc, InvalidHomeError):
+                raise
+
+            # Netatmo answers with an int here and a string elsewhere, so
+            # compare as text. The status matters too: code 21 is a generic
+            # invalid-parameter code, and only 400 states the id was rejected.
+            if exc.status != BAD_REQUEST_ERROR_CODE or str(exc.code) != str(
+                INVALID_HOME_ERROR_CODE
+            ):
+                raise
+
+            raise InvalidHomeError(
+                str(exc),
+                status=exc.status,
+                code=exc.code,
+            ) from exc
+        raw_data: RawData = extract_raw_data(await resp.json(), HOME, home_id)
         await self.homes[home_id].update(raw_data, do_raise_for_reachability_error=True)
 
     async def async_update_events(self, home_id: str) -> None:
@@ -157,7 +189,7 @@ class AsyncAccount:
             endpoint=GETEVENTS_ENDPOINT,
             params={"home_id": home_id},
         )
-        raw_data: RawData = extract_raw_data(await resp.json(), HOME)
+        raw_data: RawData = extract_raw_data(await resp.json(), HOME, home_id)
         await self.homes[home_id].update(raw_data)
 
     async def process_webhook(self, payload: dict[str, Any]) -> WebhookResult:
@@ -286,9 +318,10 @@ class AsyncAccount:
     ) -> None:
         """Update device states."""
         for device_data in raw_data.get("devices", {}):
-            if home_id := device_data.get(
-                "home_id",
-                self.find_home_of_device(device_data),
+            # `or`, not `get(..., default)`: the fallback scans every home and must
+            # not run for a device that already named the home it belongs to.
+            if home_id := device_data.get("home_id") or self.find_home_of_device(
+                device_data
             ):
                 home_name: str = device_data.get("home_name", "Unknown")
                 self.all_home_names.setdefault(home_id, home_name)
@@ -315,7 +348,14 @@ class AsyncAccount:
                     {HOME: {"modules": [normalize_weather_attributes(device_data)]}},
                 )
             else:
-                LOG.debug("No home %s (%s) found.", home_id, home_id)
+                # home_id is falsy here by definition, so name the device
+                # instead -- it is the only thing that could lead someone to the
+                # cause.
+                LOG.debug(
+                    "Skipping device %s (%s): belongs to no known home",
+                    device_data.get("_id"),
+                    device_data.get("type"),
+                )
 
             for module_data in device_data.get("modules", []):
                 module_data["home_id"] = home_id

--- a/src/pyatmo/auth.py
+++ b/src/pyatmo/auth.py
@@ -8,6 +8,7 @@ from email.utils import parsedate_to_datetime
 from json import JSONDecodeError
 import logging
 from typing import Any, Final
+from urllib.parse import urlsplit, urlunsplit
 
 from aiohttp import (
     ClientError,
@@ -30,15 +31,17 @@ from tenacity import (
 from pyatmo.const import (
     AUTHORIZATION_HEADER,
     CONCURRENCY_ERROR_CODE,
+    CONFLICT_ERROR_CODE,
     DEFAULT_BASE_URL,
     ERRORS,
     FORBIDDEN_ERROR_CODE,
+    HOME,
     THROTTLING_ERROR_CODE,
     TOO_MANY_REQUESTS_ERROR_CODE,
-    WEBHOOK_URL_ADD_ENDPOINT,
-    WEBHOOK_URL_DROP_ENDPOINT,
+    WEBHOOK_ENDPOINT,
 )
 from pyatmo.exceptions import ApiError, ApiThrottlingError, ApiTooManyRequestError
+from pyatmo.helpers import home_suffix
 
 LOG: logging.Logger = logging.getLogger(__name__)
 
@@ -50,6 +53,10 @@ INITIAL_BACKOFF = 1  # seconds
 MULTIPLIER = 1
 MAX_BACKOFF = 8  # cap on a single fallback wait
 MAX_RETRY_AFTER = 60  # cap on an honored server Retry-After hint
+
+# Rendering of a webhook URL for logs - see _redact_webhook_url.
+REDACTED_PLACEHOLDER: Final[str] = "<redacted>"
+REDACTED_TAIL_LENGTH: Final[int] = 4
 
 
 def _parse_retry_after(value: str | None) -> float | None:
@@ -84,6 +91,69 @@ _fallback_wait = wait_combine(
     wait_exponential(multiplier=MULTIPLIER, min=INITIAL_BACKOFF, max=MAX_BACKOFF),
     wait_random(0, 1),
 )
+
+
+def _redact_webhook_url(url: str) -> str:
+    """Render a webhook URL in a form that is safe to log.
+
+    A webhook URL is a capability URL: the URL is itself the credential, and
+    anyone holding it can POST forged Netatmo events into the consumer's
+    instance.
+    DEBUG is exactly the level users are asked to enable when filing a bug
+    report, so a URL logged whole ends up attached to public issues.
+
+    Keeps the scheme and host - enough to tell a Nabu Casa cloudhook from a
+    self-hosted endpoint - elides the path, and keeps a short tail so a reader
+    can tell two webhooks apart and follow one across log lines. Those few
+    characters of a high-entropy path cannot be reconstructed from, but they do
+    reach the log: the trade is deliberate, not an oversight. Anything without
+    a recognizable scheme and host is redacted whole, since its shape gives no
+    reason to believe any part is safe.
+
+    Never raises: a logging helper that throws would break the very caller it
+    is meant to protect.
+    """
+    try:
+        parts = urlsplit(url)
+        # hostname, never netloc: netloc carries userinfo, and a webhook URL
+        # behind a basic-auth proxy would otherwise publish its password.
+        host: str | None = parts.hostname
+        if not parts.scheme or not host:
+            return REDACTED_PLACEHOLDER
+
+        origin: str = f"{parts.scheme}://{host}"
+        if parts.port is not None:
+            origin = f"{origin}:{parts.port}"
+
+        # Everything after the authority is the capability secret. Rebuilt from
+        # the parsed parts rather than sliced off the input, because the
+        # rendered origin is no longer the same length as what it replaced.
+        path: str = urlunsplit(("", "", parts.path, parts.query, parts.fragment))
+    except (AttributeError, TypeError, ValueError):
+        return REDACTED_PLACEHOLDER
+
+    if not path:
+        return origin
+
+    # Only keep a tail when the path is long enough that the tail is a small
+    # part of it - four of five characters would be worse than none.
+    if len(path) > 2 * REDACTED_TAIL_LENGTH:
+        return f"{origin}/...{path[-REDACTED_TAIL_LENGTH:]}"
+
+    return f"{origin}/..."
+
+
+def _home_suffix(params: dict[str, Any] | None) -> str:
+    """Postfix a log message with the home the request names."""
+    params = params or {}
+
+    home_id: Any = params.get("home_id")
+    if not home_id:
+        body: Any = params.get("json")
+        home: Any = body.get(HOME) if isinstance(body, dict) else None
+        home_id = home.get("id") if isinstance(home, dict) else None
+
+    return home_suffix(home_id if isinstance(home_id, str) else None)
 
 
 def _wait_retry_after(retry_state: RetryCallState) -> float:
@@ -124,7 +194,7 @@ class AbstractAsyncAuth(ABC):
     ) -> bytes:
         """Wrap async get requests."""
 
-        # Note: the 429/concurrency retry lives on async_post_api_request only.
+        # Note: the 429/concurrency retry lives on the *_api_request wrappers.
         # Camera snapshots are best-effort and time-sensitive - retrying a live
         # image seconds later has no value - so this path is deliberately not
         # decorated.
@@ -189,6 +259,75 @@ class AbstractAsyncAuth(ABC):
             headers=headers,
             timeout=DEFAULT_TIMEOUT,
         ) as resp:
+            return await self.process_response(resp, url, params=params)
+
+    @retry(
+        retry=retry_if_exception_type(ApiTooManyRequestError),
+        stop=stop_after_attempt(MAX_RETRIES),
+        wait=_wait_retry_after,
+        before_sleep=before_sleep_log(LOG, logging.DEBUG),
+        reraise=True,
+    )
+    async def async_get_api_request(
+        self,
+        endpoint: str,
+        base_url: str | None = None,
+        params: dict[str, Any] | None = None,
+    ) -> ClientResponse:
+        """Wrap async get requests returning JSON."""
+
+        return await self.async_get_request(
+            url=(base_url or self.base_url) + endpoint,
+            params=params,
+        )
+
+    async def async_get_request(
+        self,
+        url: str,
+        params: dict[str, Any] | None = None,
+    ) -> ClientResponse:
+        """Wrap async get requests returning JSON."""
+
+        access_token: str = await self.get_access_token()
+        headers: dict[str, str] = {AUTHORIZATION_HEADER: f"Bearer {access_token}"}
+
+        async with self.websession.get(
+            url,
+            params=params,
+            headers=headers,
+            timeout=DEFAULT_TIMEOUT,
+        ) as resp:
+            return await self.process_response(resp, url, params=params)
+
+    @retry(
+        retry=retry_if_exception_type(ApiTooManyRequestError),
+        stop=stop_after_attempt(MAX_RETRIES),
+        wait=_wait_retry_after,
+        before_sleep=before_sleep_log(LOG, logging.DEBUG),
+        reraise=True,
+    )
+    async def async_delete_api_request(
+        self,
+        endpoint: str,
+        base_url: str | None = None,
+    ) -> ClientResponse:
+        """Wrap async delete requests."""
+
+        return await self.async_delete_request(
+            url=(base_url or self.base_url) + endpoint,
+        )
+
+    async def async_delete_request(self, url: str) -> ClientResponse:
+        """Wrap async delete requests."""
+
+        access_token: str = await self.get_access_token()
+        headers: dict[str, str] = {AUTHORIZATION_HEADER: f"Bearer {access_token}"}
+
+        async with self.websession.delete(
+            url,
+            headers=headers,
+            timeout=DEFAULT_TIMEOUT,
+        ) as resp:
             return await self.process_response(resp, url)
 
     async def get_access_token(self) -> str:
@@ -213,14 +352,29 @@ class AbstractAsyncAuth(ABC):
 
         return req_args
 
-    async def process_response(self, resp: ClientResponse, url: str) -> ClientResponse:
-        """Process response."""
+    async def process_response(
+        self,
+        resp: ClientResponse,
+        url: str,
+        params: dict[str, Any] | None = None,
+    ) -> ClientResponse:
+        """Process response.
+
+        ``params`` is the request payload; it is used solely to name the home
+        the failed request was for - the home id travels in the body, not the
+        URL, so an error is otherwise unattributable.
+        """
         resp_status: int = resp.status
         resp_content: bytes = await resp.read()
 
         if not resp.ok:
-            LOG.debug("The Netatmo API returned %s (%s)", resp_content, resp_status)
-            await self.handle_error_response(resp, resp_status, url)
+            LOG.debug(
+                "The Netatmo API returned %s (%s)%s",
+                resp_content,
+                resp_status,
+                _home_suffix(params),
+            )
+            await self.handle_error_response(resp, resp_status, url, params)
 
         return await self.handle_success_response(resp, resp_content)
 
@@ -229,8 +383,11 @@ class AbstractAsyncAuth(ABC):
         resp: ClientResponse,
         resp_status: int,
         url: str,
+        params: dict[str, Any] | None = None,
     ) -> None:
         """Handle error response."""
+        suffix: str = _home_suffix(params)
+
         try:
             resp_json: dict[str, Any] = await resp.json()
             error: dict[str, Any] = resp_json.get("error", {})
@@ -242,6 +399,7 @@ class AbstractAsyncAuth(ABC):
                 f"{error.get('message')} "
                 f"({error_code}) "
                 f"when accessing '{url}'"
+                f"{suffix}"
             )
 
             if (
@@ -249,23 +407,35 @@ class AbstractAsyncAuth(ABC):
                 and error_code == CONCURRENCY_ERROR_CODE
             ):
                 retry_after = _parse_retry_after(resp.headers.get("Retry-After"))
-                raise ApiTooManyRequestError(message, retry_after=retry_after)
+                raise ApiTooManyRequestError(
+                    message,
+                    retry_after=retry_after,
+                    status=resp_status,
+                    code=error_code,
+                )
 
             if (
                 resp_status == FORBIDDEN_ERROR_CODE
                 and error_code == THROTTLING_ERROR_CODE
             ):
-                raise ApiThrottlingError(message)
+                raise ApiThrottlingError(message, status=resp_status, code=error_code)
 
-            raise ApiError(message)
+            # Deliberately no special case for a rejected home id here: the
+            # code that says so - 21 - is a generic invalid-parameter code that
+            # addwebhook also answers a bad URL with, and this layer sees only a
+            # status, a code and a URL. Callers with the request context in hand
+            # read the code off the exception; see AsyncAccount.async_update_status.
+            raise ApiError(message, status=resp_status, code=error_code)
 
         except (JSONDecodeError, ContentTypeError) as exc:
             msg: str = (
                 f"{resp_status} - "
                 f"{ERRORS.get(resp_status, '')} - "
                 f"when accessing '{url}'"
+                f"{suffix}"
             )
-            raise ApiError(msg) from exc
+            # No code: the body that would have carried it could not be read.
+            raise ApiError(msg, status=resp_status) from exc
 
     async def handle_success_response(
         self,
@@ -286,27 +456,88 @@ class AbstractAsyncAuth(ABC):
         return resp
 
     async def async_addwebhook(self, webhook_url: str) -> None:
-        """Register webhook."""
+        """Register a webhook URL for this application."""
         try:
-            resp: ClientResponse = await self.async_post_api_request(
-                endpoint=WEBHOOK_URL_ADD_ENDPOINT,
-                params={"url": webhook_url},
+            resp: ClientResponse = await self._async_post_webhook(webhook_url)
+        except ApiError as exc:
+            if exc.status != CONFLICT_ERROR_CODE:
+                raise
+
+            # One webhook per application: clear the incumbent and try once
+            # more. A second conflict is surfaced rather than retried.
+            try:
+                await self.async_delete_api_request(endpoint=WEBHOOK_ENDPOINT)
+            except TimeoutError as timeout:
+                msg = "Webhook removal during replacement timed out"
+                raise ApiError(msg) from timeout
+
+            resp = await self._async_post_webhook(webhook_url)
+
+        LOG.debug("addwebhook: %s", resp)
+
+    async def _async_post_webhook(self, webhook_url: str) -> ClientResponse:
+        """POST the registration, reporting a timeout as an ApiError."""
+        try:
+            return await self.async_post_api_request(
+                endpoint=WEBHOOK_ENDPOINT,
+                params={"json": {"url": webhook_url}},
             )
         except TimeoutError as exc:
             msg: str = "Webhook registration timed out"
             raise ApiError(msg) from exc
-        else:
-            LOG.debug("addwebhook: %s", resp)
 
     async def async_dropwebhook(self) -> None:
-        """Unregister webhook."""
+        """Unregister this application's webhook."""
         try:
-            resp: ClientResponse = await self.async_post_api_request(
-                endpoint=WEBHOOK_URL_DROP_ENDPOINT,
-                params={"app_types": "app_security"},
+            resp: ClientResponse = await self.async_delete_api_request(
+                endpoint=WEBHOOK_ENDPOINT,
             )
         except TimeoutError as exc:
-            msg: str = "Webhook registration timed out"
+            msg: str = "Webhook removal timed out"
             raise ApiError(msg) from exc
         else:
             LOG.debug("dropwebhook: %s", resp)
+
+    async def async_list_webhooks(self) -> list[str]:
+        """Return the webhook URLs currently registered for this application."""
+        try:
+            resp: ClientResponse = await self.async_get_api_request(
+                endpoint=WEBHOOK_ENDPOINT,
+            )
+        except TimeoutError as exc:
+            msg: str = "Webhook listing timed out"
+            raise ApiError(msg) from exc
+
+        try:
+            resp_json: Any = await resp.json()
+        except (JSONDecodeError, ContentTypeError) as exc:
+            msg = "Invalid response when listing webhooks"
+            raise ApiError(msg) from exc
+
+        body: Any = resp_json.get("body") if isinstance(resp_json, dict) else None
+        if not isinstance(body, list):
+            # Messages carry types only - a webhook URL is a capability URL.
+            msg = f"Unexpected payload when listing webhooks: {type(body).__name__}"
+            raise ApiError(msg)
+
+        webhooks: list[str] = []
+        for entry in body:
+            url: Any = entry.get("url") if isinstance(entry, dict) else None
+            if not isinstance(url, str):
+                # Keys only, never values, for the same reason.
+                detail: Any = (
+                    sorted(entry) if isinstance(entry, dict) else type(entry).__name__
+                )
+                msg = f"Unexpected webhook entry when listing webhooks: {detail}"
+                raise ApiError(msg)
+            webhooks.append(url)
+
+        # Count first: it is the part a health check reads. The URLs are
+        # capability URLs, so they are only ever rendered redacted.
+        LOG.debug(
+            "list_webhooks: %s registered %s",
+            len(webhooks),
+            [_redact_webhook_url(url) for url in webhooks],
+        )
+
+        return webhooks

--- a/src/pyatmo/const.py
+++ b/src/pyatmo/const.py
@@ -10,6 +10,8 @@ ERRORS: dict[int, str] = {
     403: "Forbidden",
     404: "Not found",
     406: "Not Acceptable",
+    409: "Conflict",
+    429: "Too Many Requests",
     500: "Internal Server Error",
     502: "Bad Gateway",
     503: "Service Unavailable",
@@ -27,8 +29,9 @@ SIREN_BASE_URL: str = "https://app.netatmo.net/"
 # Endpoints
 AUTH_REQ_ENDPOINT = "oauth2/token"
 AUTH_URL_ENDPOINT = "oauth2/authorize"
-WEBHOOK_URL_ADD_ENDPOINT = "api/addwebhook"
-WEBHOOK_URL_DROP_ENDPOINT = "api/dropwebhook"
+# Note: the REST webhook surface carries no "api/" prefix, unlike every other
+# endpoint here; it serves GET, POST and DELETE for the single registration.
+WEBHOOK_ENDPOINT = "webhooks/v1"
 
 GETHOMESDATA_ENDPOINT = "api/homesdata"
 GETHOMESTATUS_ENDPOINT = "api/homestatus"
@@ -136,8 +139,11 @@ UNKNOWN = "unknown"
 
 # Error codes
 CONCURRENCY_ERROR_CODE = 11
+INVALID_HOME_ERROR_CODE = 21
 THROTTLING_ERROR_CODE = 26
+BAD_REQUEST_ERROR_CODE = 400
 FORBIDDEN_ERROR_CODE = 403
+CONFLICT_ERROR_CODE = 409
 TOO_MANY_REQUESTS_ERROR_CODE = 429
 
 # Location constants

--- a/src/pyatmo/exceptions.py
+++ b/src/pyatmo/exceptions.py
@@ -9,10 +9,6 @@ class InvalidScheduleError(Exception):
     """Raised when an invalid schedule is encountered."""
 
 
-class InvalidHomeError(Exception):
-    """Raised when an invalid home is encountered."""
-
-
 class InvalidRoomError(Exception):
     """Raised when an invalid room is encountered."""
 
@@ -22,7 +18,47 @@ class NoDeviceError(Exception):
 
 
 class ApiError(Exception):
-    """Raised when an API error is encountered."""
+    """Raised when an API error is encountered.
+
+    ``status`` (the HTTP status) and ``code`` (the Netatmo error code) are
+    carried whenever the response yielded them, and are ``None`` otherwise -
+    an unreadable body still produces an error, just without a code.
+
+    They exist because Netatmo reuses one code across unrelated endpoints:
+    ``400`` + code 21 answers both a rejected home id and an ``addwebhook``
+    URL whose host does not resolve. Only a caller that knows what it asked
+    for can turn such a pair into a specific exception.
+
+    ``code`` is typed ``int | str`` because Netatmo is not consistent: the
+    legacy ``api/*`` endpoints answer with integers (11, 21, 26), while
+    ``webhooks/v1`` answers with strings such as ``"WH009"``. Whatever arrived
+    is passed through unconverted, so a comparison against an integer code
+    simply does not match a string one.
+    """
+
+    def __init__(
+        self,
+        message: str = "",
+        status: int | None = None,
+        code: int | str | None = None,
+    ) -> None:
+        """Initialize with the HTTP status and Netatmo error code, when known.
+
+        ``message`` defaults so that ``ApiError()`` keeps working: this class
+        inherited ``Exception.__init__`` before it carried a status and a code,
+        and it is public API.
+        """
+        super().__init__(message)
+        self.status = status
+        self.code = code
+
+
+class InvalidHomeError(ApiError):
+    """Raised when the API rejects a home id.
+
+    Deterministic: the same home id will be rejected on every future call, so a
+    caller should stop polling that home rather than retry it.
+    """
 
 
 class ApiThrottlingError(ApiError):
@@ -40,7 +76,13 @@ class InvalidStateError(Exception):
 class ApiTooManyRequestError(ApiError):
     """Raised when API returned 429 code 11."""
 
-    def __init__(self, message: str, retry_after: float | None = None) -> None:
+    def __init__(
+        self,
+        message: str = "",
+        retry_after: float | None = None,
+        status: int | None = None,
+        code: int | str | None = None,
+    ) -> None:
         """Initialize with an optional server-provided retry delay (seconds)."""
-        super().__init__(message)
+        super().__init__(message, status=status, code=code)
         self.retry_after = retry_after

--- a/src/pyatmo/helpers.py
+++ b/src/pyatmo/helpers.py
@@ -73,21 +73,38 @@ def fix_id(raw_data: list[RawData | str]) -> list[RawData | str]:
     return raw_data
 
 
-def extract_raw_data(resp: RawData, tag: str) -> RawData:
-    """Extract raw data from server response."""
+def home_suffix(home_id: str | None) -> str:
+    """Return ``" for home <id>"`` for a home id, else ``""``.
+
+    Shared by every log line and error message that can name a home, so the
+    wording stays identical across modules and an absent home id costs no
+    trailing noise.
+    """
+    return f" for home {home_id}" if home_id else ""
+
+
+def extract_raw_data(resp: RawData, tag: str, home_id: str | None = None) -> RawData:
+    """Extract raw data from server response.
+
+    ``home_id`` is optional and used solely to name the home the request was
+    for: the id travels in the request body, never in the response, so a
+    body-less 200 is otherwise unattributable on a multi-home account.
+    """
     if tag == "body":
         return {"public": resp["body"], "errors": []}
 
+    suffix: str = home_suffix(home_id)
+
     if resp is None or "body" not in resp or tag not in resp["body"]:
-        LOG.debug("Server response (tag: %s): %s", tag, resp)
-        msg = "No device found, errors in response"
+        LOG.debug("Server response (tag: %s)%s: %s", tag, suffix, resp)
+        msg = f"No device found, errors in response{suffix}"
         raise NoDeviceError(msg)
 
     if tag == "homes":
         homes: list[RawData | str] = fix_id(resp["body"].get(tag))
         if not homes:
-            LOG.debug("Server response (tag: %s): %s", tag, resp)
-            msg = "No homes found"
+            LOG.debug("Server response (tag: %s)%s: %s", tag, suffix, resp)
+            msg = f"No homes found{suffix}"
             raise NoDeviceError(msg)
         return {
             tag: homes,
@@ -95,8 +112,8 @@ def extract_raw_data(resp: RawData, tag: str) -> RawData:
         }
 
     if not (raw_data := fix_id(resp["body"].get(tag))):
-        LOG.debug("Server response (tag: %s): %s", tag, resp)
-        msg = "No device data available"
+        LOG.debug("Server response (tag: %s)%s: %s", tag, suffix, resp)
+        msg = f"No device data available{suffix}"
         raise NoDeviceError(msg)
 
     return {tag: raw_data, "errors": resp["body"].get("errors", [])}

--- a/src/pyatmo/home.py
+++ b/src/pyatmo/home.py
@@ -131,6 +131,19 @@ class Home:
                 module=module,
             )
 
+    @property
+    def has_status(self) -> bool:
+        """Whether `/homestatus` can be called for this home.
+
+        A home carrying no modules has nothing to report: `/homestatus` answers
+        `200 {"status": "ok"}` with no `body`, which raises `NoDeviceError` on
+        every call, so a caller should not schedule it.
+
+        Device category deliberately plays no part: `/homestatus` does report
+        weather modules, so excluding them would hide a home that polls fine.
+        """
+        return bool(self.modules)
+
     def update_topology(self, raw_data: RawData) -> None:
         """Update topology."""
 

--- a/src/pyatmo/webhook.py
+++ b/src/pyatmo/webhook.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field, replace
 from enum import Enum
 import logging
+from time import time
 from typing import TYPE_CHECKING, Any, NamedTuple, cast
 
 from pyatmo.event import EventTypes
@@ -181,9 +182,10 @@ def classify(event_type: str | None, push_type: str | None) -> WebhookKind:
     """Route a webhook payload to a WebhookKind by event_type/push_type."""
     if push_type in (WEBHOOK_ACTIVATION, WEBHOOK_DEACTIVATION):
         return WebhookKind.LIFECYCLE
-    if push_type in CAMERA_CONNECTION_WEBHOOKS or event_type in (
-        "connection",
-        "disconnection",
+    if (
+        push_type in CAMERA_CONNECTION_WEBHOOKS
+        or event_type == "connection"
+        or _is_disconnection(event_type, push_type)
     ):
         return WebhookKind.LIFECYCLE
     if event_type in STATE_EVENT_TYPES:
@@ -333,6 +335,10 @@ async def process_webhook(
     payload: dict[str, Any],
 ) -> WebhookResult:
     """Parse, normalize, and merge a Netatmo webhook payload."""
+    # Delivery of anything, including a payload this library cannot classify,
+    # proves the webhook path works end to end.
+    account.last_webhook_at = time()
+
     event_type = str_or_none(payload.get("event_type"))
     push_type = str_or_none(payload.get("push_type"))
     home_id = resolve_home_id(payload)

--- a/tests/common.py
+++ b/tests/common.py
@@ -22,6 +22,10 @@ class MockResponse:
         self.status = status
         self.headers = headers or {}
 
+    @property
+    def ok(self):
+        return self.status < 400
+
     async def json(self):
         return self._text
 

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -7,8 +7,10 @@ import pytest
 
 import pyatmo
 from pyatmo import modules
+from pyatmo.const import INVALID_HOME_ERROR_CODE
+from pyatmo.exceptions import NoDeviceError
 
-from .common import fake_post_request_multi
+from .common import MockResponse, fake_post_request_multi
 
 
 async def test_update_devices_unknown_type_falls_back_to_nlunknown(async_account):
@@ -176,6 +178,134 @@ async def test_update_measures_disabled_home_skips_call(async_auth, caplog):
     assert "home_disabled" in caplog.text
 
 
+async def test_update_status_body_less_response_names_the_home(async_account, caplog):
+    """A 200 without a `body` names the home the /homestatus call was for.
+
+    The real API answers `{"status": "ok", "time_server": ...}` for some homes,
+    and the resulting NoDeviceError used to be unattributable on an account
+    holding more than one home.
+    """
+    home_id = "91763b24c43d3e344f424e8b"
+
+    async def _body_less_response(*_args, **_kwargs):
+        return MockResponse({"status": "ok", "time_server": 1786656837}, 200)
+
+    with (
+        patch(
+            "pyatmo.auth.AbstractAsyncAuth.async_post_api_request",
+            _body_less_response,
+        ),
+        caplog.at_level(logging.DEBUG, logger="pyatmo.helpers"),
+        pytest.raises(NoDeviceError) as exc_info,
+    ):
+        await async_account.async_update_status(home_id)
+
+    assert f"for home {home_id}" in str(exc_info.value)
+    assert f"for home {home_id}" in caplog.text
+
+
+async def test_update_status_rejected_home_raises_invalid_home_error(async_account):
+    """A home the API rejects with 400 + code 21 surfaces as InvalidHomeError.
+
+    The translation lives here rather than in the auth layer: code 21 is a
+    generic invalid-parameter code Netatmo also answers `addwebhook` with, so
+    only the caller that sent a home id can read it as a rejected home.
+    """
+    home_id = "91763b24c43d3e344f424e8b"
+    message = "400 - Bad request - Invalid home_id (21) when accessing '/homestatus'"
+
+    async def _rejected(*_args, **_kwargs):
+        raise pyatmo.exceptions.ApiError(message, status=400, code=21)
+
+    with (
+        patch("pyatmo.auth.AbstractAsyncAuth.async_post_api_request", _rejected),
+        pytest.raises(pyatmo.exceptions.InvalidHomeError) as exc_info,
+    ):
+        await async_account.async_update_status(home_id)
+
+    assert str(exc_info.value) == message
+    assert exc_info.value.code == 21
+    assert exc_info.value.status == 400
+    assert isinstance(exc_info.value.__cause__, pyatmo.exceptions.ApiError)
+
+
+async def test_update_status_other_api_error_stays_generic(async_account):
+    """Any other API failure passes through unchanged.
+
+    Only code 21 means the home id was refused; everything else stays a plain
+    ApiError so a caller does not stop polling a home over an unrelated fault.
+    """
+    home_id = "91763b24c43d3e344f424e8b"
+    message = (
+        "400 - Bad request - Invalid access token (2) when accessing '/homestatus'"
+    )
+
+    async def _rejected(*_args, **_kwargs):
+        raise pyatmo.exceptions.ApiError(message, status=400, code=2)
+
+    with (
+        patch("pyatmo.auth.AbstractAsyncAuth.async_post_api_request", _rejected),
+        pytest.raises(pyatmo.exceptions.ApiError) as exc_info,
+    ):
+        await async_account.async_update_status(home_id)
+
+    assert not isinstance(exc_info.value, pyatmo.exceptions.InvalidHomeError)
+    assert str(exc_info.value) == message
+
+
+async def test_update_status_string_error_code_stays_generic(async_account):
+    """A string error code is never read as the rejected-home code 21.
+
+    ``webhooks/v1`` answers with string codes such as ``WH009`` while the
+    ``api/*`` endpoints answer with integers, so an ``ApiError`` reaching this
+    caller may carry either. A string equals no integer constant, so the error
+    passes through untranslated and with its code intact.
+    """
+    home_id = "91763b24c43d3e344f424e8b"
+    message = "409 - Conflict - webhook limit reached (WH009)"
+
+    async def _rejected(*_args, **_kwargs):
+        raise pyatmo.exceptions.ApiError(message, status=409, code="WH009")
+
+    with (
+        patch("pyatmo.auth.AbstractAsyncAuth.async_post_api_request", _rejected),
+        pytest.raises(pyatmo.exceptions.ApiError) as exc_info,
+    ):
+        await async_account.async_update_status(home_id)
+
+    assert not isinstance(exc_info.value, pyatmo.exceptions.InvalidHomeError)
+    assert exc_info.value.code == "WH009"
+    assert exc_info.value.code != INVALID_HOME_ERROR_CODE
+
+
+def test_invalid_home_error_is_an_api_error():
+    """Consumers catching ApiError keep catching this one.
+
+    Home Assistant's `async_fetch_data` catches `ApiError`; anything else
+    escapes and breaks its update loop.
+    """
+    assert issubclass(pyatmo.exceptions.InvalidHomeError, pyatmo.exceptions.ApiError)
+
+
+async def test_update_events_body_less_response_names_the_home(async_account):
+    """/getevents gets the same treatment as /homestatus."""
+    home_id = "91763b24c43d3e344f424e8b"
+
+    async def _body_less_response(*_args, **_kwargs):
+        return MockResponse({"status": "ok", "time_server": 1786656837}, 200)
+
+    with (
+        patch(
+            "pyatmo.auth.AbstractAsyncAuth.async_post_api_request",
+            _body_less_response,
+        ),
+        pytest.raises(NoDeviceError) as exc_info,
+    ):
+        await async_account.async_update_events(home_id)
+
+    assert f"for home {home_id}" in str(exc_info.value)
+
+
 async def test_set_state_disabled_home_skips_call(async_auth, caplog):
     """A disabled home_id logs a warning and makes no API request."""
     account = pyatmo.AsyncAccount(async_auth, disabled_homes_ids=["home_disabled"])
@@ -185,3 +315,94 @@ async def test_set_state_disabled_home_skips_call(async_auth, caplog):
 
     async_auth.async_post_api_request.assert_not_called()
     assert "home_disabled" in caplog.text
+
+
+async def test_update_devices_names_the_device_it_cannot_place(
+    async_account,
+    caplog,
+):
+    """A device with no resolvable home is identified, not logged as None.
+
+    Standalone weather and air-care devices legitimately reach this branch, so
+    the line is expected traffic and must not be silenced -- but it named
+    nothing, rendering as "None (None)" for every such device.
+    """
+    device_data = {"_id": "99:99:99:99:99:99", "type": "NAMain"}
+
+    with caplog.at_level(logging.DEBUG, logger="pyatmo.account"):
+        await async_account.update_devices({"devices": [device_data]})
+
+    assert "99:99:99:99:99:99" in caplog.text
+    assert "NAMain" in caplog.text
+    assert "None (None)" not in caplog.text
+
+
+async def test_update_devices_does_not_search_when_the_home_is_known(async_account):
+    """The fallback search must not run for a device that names its home.
+
+    ``NHC`` because the later standalone-device check short-circuits on that
+    type; any other type would call ``find_home_of_device`` again from there,
+    for the unrelated question of whether the device is a member of a home.
+    """
+    device_data = {
+        "_id": "99:99:99:99:99:99",
+        "type": "NHC",
+        "home_id": "known_home",
+        "home_name": "Known",
+        "modules": [],
+    }
+
+    with patch.object(async_account, "find_home_of_device") as mock_find:
+        await async_account.update_devices({"devices": [device_data]})
+
+    mock_find.assert_not_called()
+
+
+async def test_update_status_translates_a_string_error_code(async_account):
+    """Netatmo is inconsistent about code types; both must translate."""
+    message = "400 - Bad request - Invalid home_id (21)"
+
+    async def _rejected(*_args, **_kwargs):
+        raise pyatmo.exceptions.ApiError(message, status=400, code="21")
+
+    with (
+        patch("pyatmo.auth.AbstractAsyncAuth.async_post_api_request", _rejected),
+        pytest.raises(pyatmo.exceptions.InvalidHomeError),
+    ):
+        await async_account.async_update_status("whatever")
+
+
+async def test_update_status_ignores_code_21_from_another_status(async_account):
+    """The contract is 400 plus code 21, not code 21 on any status."""
+    message = "500 - Internal Server Error - (21)"
+
+    async def _rejected(*_args, **_kwargs):
+        raise pyatmo.exceptions.ApiError(message, status=500, code=21)
+
+    with (
+        patch("pyatmo.auth.AbstractAsyncAuth.async_post_api_request", _rejected),
+        pytest.raises(pyatmo.exceptions.ApiError) as exc_info,
+    ):
+        await async_account.async_update_status("whatever")
+
+    assert not isinstance(exc_info.value, pyatmo.exceptions.InvalidHomeError)
+
+
+async def test_update_status_passes_through_an_invalid_home_error(async_account):
+    """An InvalidHomeError from below is not wrapped in a second one."""
+    original = pyatmo.exceptions.InvalidHomeError(
+        "already specific",
+        status=400,
+        code=21,
+    )
+
+    async def _rejected(*_args, **_kwargs):
+        raise original
+
+    with (
+        patch("pyatmo.auth.AbstractAsyncAuth.async_post_api_request", _rejected),
+        pytest.raises(pyatmo.exceptions.InvalidHomeError) as exc_info,
+    ):
+        await async_account.async_update_status("whatever")
+
+    assert exc_info.value is original

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
 from email.utils import format_datetime
+from json import JSONDecodeError
+import logging
+from urllib.parse import quote, urlencode, urlsplit
 
+from aiohttp import ContentTypeError
 import pytest
 from tenacity import Future, RetryCallState
 
@@ -13,11 +17,19 @@ from pyatmo.auth import (
     MAX_BACKOFF,
     MAX_RETRIES,
     MAX_RETRY_AFTER,
+    REDACTED_TAIL_LENGTH,
     AbstractAsyncAuth,
     _parse_retry_after,
+    _redact_webhook_url,
     _wait_retry_after,
 )
-from pyatmo.exceptions import ApiError, ApiThrottlingError, ApiTooManyRequestError
+from pyatmo.const import CONCURRENCY_ERROR_CODE, THROTTLING_ERROR_CODE
+from pyatmo.exceptions import (
+    ApiError,
+    ApiThrottlingError,
+    ApiTooManyRequestError,
+    InvalidHomeError,
+)
 
 from .common import MockResponse
 
@@ -58,6 +70,29 @@ def test_too_many_request_error_carries_retry_after():
 def test_too_many_request_error_defaults_retry_after_none():
     """retry_after defaults to None when not provided."""
     assert ApiTooManyRequestError("boom").retry_after is None
+
+
+@pytest.mark.parametrize("cls", [ApiError, ApiTooManyRequestError])
+def test_api_error_constructs_without_arguments(cls):
+    """Every argument stays optional, as before status and code existed.
+
+    These are public exception classes that used to inherit
+    ``Exception.__init__``, so downstream code may construct them bare.
+    """
+    err = cls()
+
+    assert str(err) == ""
+    assert err.status is None
+    assert err.code is None
+
+
+def test_api_error_carries_status_and_code():
+    """Both are exposed for a caller that must tell one error code apart."""
+    err = ApiError("boom", status=400, code=21)
+
+    assert str(err) == "boom"
+    assert err.status == 400
+    assert err.code == 21
 
 
 def test_parse_retry_after_delta_seconds():
@@ -228,3 +263,1079 @@ async def test_post_api_request_does_not_retry_other_errors(auth):
         await auth.async_post_api_request(endpoint="api/homestatus")
 
     assert calls == 1
+
+
+# Obviously fake, shaped like a Nabu Casa cloudhook. Never use a real one: a
+# webhook URL is a capability URL, and this file is public.
+FAKE_SECRET = "gAAAAABn0tR34LacApab1l1tyUrlJUSTF4KEd0N0tUs3z9Qb="
+FAKE_CLOUDHOOK = f"https://hooks.nabu.casa/{FAKE_SECRET}"
+
+
+def test_redact_webhook_url_keeps_origin_elides_secret_keeps_tail():
+    """The scheme and host survive; all but the last few secret chars do not.
+
+    The host distinguishes a Nabu Casa cloudhook from a self-hosted endpoint,
+    and the short tail lets a reader tell two webhooks apart and follow one
+    across log lines. The tail is a deliberate, bounded exception -- nothing
+    beyond REDACTED_TAIL_LENGTH characters may ever reach a log.
+    """
+    redacted = _redact_webhook_url(FAKE_CLOUDHOOK)
+
+    assert redacted == "https://hooks.nabu.casa/...9Qb="
+    for length in range(REDACTED_TAIL_LENGTH + 1, len(FAKE_SECRET) + 1):
+        assert FAKE_SECRET[-length:] not in redacted
+
+
+def test_redact_webhook_url_keeps_a_self_hosted_host():
+    """A self-hosted endpoint stays recognizable as such."""
+    redacted = _redact_webhook_url(
+        "https://hass.example.org:8123/api/webhook/s3cr3t-webhook-id-4242",
+    )
+
+    assert redacted == "https://hass.example.org:8123/...4242"
+    assert "s3cr3t-webhook-id" not in redacted
+    assert "/api/webhook/" not in redacted
+
+
+def test_redact_webhook_url_without_path_returns_the_origin():
+    """No path means no secret to elide."""
+    assert _redact_webhook_url("https://example.com") == "https://example.com"
+
+
+def test_redact_webhook_url_short_path_keeps_no_tail():
+    """A path too short to keep a tail from is elided whole.
+
+    Showing four of five secret characters would be worse than showing none.
+    """
+    redacted = _redact_webhook_url("https://example.com/s3cr3t")
+
+    assert redacted == "https://example.com/..."
+    assert "s3cr3t" not in redacted
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "",
+        "not-a-url",
+        "hooks.nabu.casa/s3cr3t",
+        "/api/webhook/s3cr3t",
+        "https:///s3cr3t",
+        "s3cr3t",
+    ],
+)
+def test_redact_webhook_url_redacts_anything_without_an_origin(value):
+    """Without a recognizable scheme and host, nothing is assumed safe."""
+    redacted = _redact_webhook_url(value)
+
+    assert redacted == "<redacted>"
+    assert "s3cr3t" not in redacted
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "",
+        " ",
+        "https://[oops",
+        "https://[::1",
+        "http://",
+        "://",
+        "\x00",
+        "https://example.com/" + "x" * 10000,
+        FAKE_CLOUDHOOK,
+    ],
+)
+def test_redact_webhook_url_never_raises(value):
+    """A logging helper that throws would break the caller it was meant to protect."""
+    assert isinstance(_redact_webhook_url(value), str)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "https://ha:Passw0rd@ha.example.org/api/webhook/abcdefghij",
+        "https://ha:Passw0rd@ha.example.org:8123/api/webhook/abcdefghij",
+        "https://token@ha.example.org/api/webhook/abcdefghij",
+    ],
+)
+def test_redact_webhook_url_drops_userinfo(value):
+    """Credentials in the authority must never reach a log.
+
+    urlsplit keeps userinfo in netloc, so rendering the netloc verbatim
+    would publish the password of anyone fronting Home Assistant with a
+    basic-auth reverse proxy.
+    """
+    redacted = _redact_webhook_url(value)
+
+    # Parsed rather than prefix-matched: startswith would also accept
+    # "https://ha.example.org.evil.test/", so it does not pin the host.
+    parsed = urlsplit(redacted)
+
+    assert parsed.scheme == "https"
+    assert parsed.hostname == "ha.example.org"
+    assert parsed.username is None
+    assert parsed.password is None
+    assert "Passw0rd" not in redacted
+    assert "token" not in redacted
+
+
+# The transport method each verb reaches, so a stub can replace one by name.
+_TRANSPORT = {
+    "get": "async_get_request",
+    "post": "async_post_request",
+    "delete": "async_delete_request",
+}
+
+
+def _stub(auth, verb, payload=None, exc=None):
+    """Replace one auth transport with a stub, returning the kwargs it saw.
+
+    The returned dict is updated in place on every call, so a test reads it
+    after awaiting the code under test. Use ``_stub_sequence`` instead when the
+    call count matters or successive calls must answer differently.
+    """
+    seen = {}
+
+    async def fake_request(*_args, **kwargs):
+        seen.update(kwargs)
+        if exc is not None:
+            raise exc
+        return MockResponse({"status": "ok"} if payload is None else payload, 200)
+
+    setattr(auth, _TRANSPORT[verb], fake_request)
+    return seen
+
+
+def _stub_sequence(auth, verb, results):
+    """Return each result in turn: an exception is raised, else a response.
+
+    Every call is recorded separately, unlike ``_stub``, so a test can assert
+    how many times the transport was reached and with what.
+    """
+    calls = []
+
+    async def fake_request(*_args, **kwargs):
+        calls.append(kwargs)
+        result = results[len(calls) - 1]
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+    setattr(auth, _TRANSPORT[verb], fake_request)
+    return calls
+
+
+async def test_list_webhooks_returns_registered_url(auth):
+    """A registered webhook is returned as a single-entry list."""
+    _stub(auth, "get", {"status": "ok", "body": [{"url": "https://example.com/hook"}]})
+
+    assert await auth.async_list_webhooks() == ["https://example.com/hook"]
+
+
+async def test_list_webhooks_hits_expected_url(auth):
+    """The listing endpoint is appended to the base URL without an api/ prefix."""
+    seen = _stub(auth, "get", {"status": "ok", "body": []})
+
+    await auth.async_list_webhooks()
+
+    assert seen["url"] == "https://api.netatmo.com/webhooks/v1"
+
+
+async def test_list_webhooks_empty_body(auth):
+    """No registered webhook yields an empty list."""
+    _stub(auth, "get", {"status": "ok", "body": []})
+
+    assert await auth.async_list_webhooks() == []
+
+
+async def test_list_webhooks_multiple_urls_in_order(auth):
+    """Several registered webhooks are all returned, in payload order."""
+    _stub(
+        auth,
+        "get",
+        {
+            "status": "ok",
+            "body": [
+                {"url": "https://a.example.com/hook"},
+                {"url": "https://b.example.com/hook"},
+            ],
+        },
+    )
+
+    assert await auth.async_list_webhooks() == [
+        "https://a.example.com/hook",
+        "https://b.example.com/hook",
+    ]
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"status": "ok"},
+        {"status": "ok", "body": None},
+        {"status": "ok", "body": {"url": "https://example.com/hook"}},
+        {"status": "ok", "body": "nope"},
+        [],
+        None,
+    ],
+)
+async def test_list_webhooks_unexpected_shape_raises_api_error(auth, payload):
+    """A missing or non-list body is a failed check, not a confirmed absence.
+
+    Returning [] here would tell a caller no webhook is registered, which an
+    unreadable answer does not prove.
+    """
+    _stub(auth, "get", payload)
+
+    with pytest.raises(ApiError, match="Unexpected payload when listing webhooks"):
+        await auth.async_list_webhooks()
+
+
+@pytest.mark.parametrize(
+    "entry",
+    [
+        {"app_type": "app_security"},
+        "not-a-dict",
+        {"url": None},
+    ],
+)
+async def test_list_webhooks_unexpected_entry_raises_api_error(auth, entry):
+    """An entry without a usable 'url' means the listing cannot be trusted.
+
+    Skipping it could hide our own registration and read as an absence.
+    """
+    _stub(
+        auth,
+        "get",
+        {"status": "ok", "body": [entry, {"url": "https://example.com/hook"}]},
+    )
+
+    with pytest.raises(ApiError, match="Unexpected webhook entry"):
+        await auth.async_list_webhooks()
+
+
+async def test_list_webhooks_error_message_omits_urls(auth):
+    """A malformed entry is reported by its keys, never its values.
+
+    A webhook URL is a capability URL; it must not reach an exception message.
+    """
+    _stub(
+        auth,
+        "get",
+        {
+            "status": "ok",
+            "body": [{"uri": "https://secret.example.com/hook"}],
+        },
+    )
+
+    with pytest.raises(ApiError) as excinfo:
+        await auth.async_list_webhooks()
+
+    assert "secret.example.com" not in str(excinfo.value)
+    assert "uri" in str(excinfo.value)
+
+
+async def test_list_webhooks_propagates_api_error(auth):
+    """An API error from the request path propagates untouched."""
+    boom = "boom"
+    _stub(auth, "get", exc=ApiError(boom))
+
+    with pytest.raises(ApiError, match=boom):
+        await auth.async_list_webhooks()
+
+
+async def test_list_webhooks_timeout_raises_api_error(auth):
+    """A TimeoutError surfaces as ApiError, like the add/drop helpers."""
+    _stub(auth, "get", exc=TimeoutError)
+
+    with pytest.raises(ApiError, match="timed out"):
+        await auth.async_list_webhooks()
+
+
+class _UnparsableResponse(MockResponse):
+    """A 200 response whose body cannot be parsed as JSON."""
+
+    def __init__(self, exc):
+        super().__init__(None, 200)
+        self._exc = exc
+
+    async def json(self):
+        raise self._exc
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        ContentTypeError(None, ()),
+        JSONDecodeError("Expecting value", "<html>", 0),
+    ],
+)
+async def test_list_webhooks_unparsable_body_raises_api_error(auth, exc):
+    """A 200 that is not JSON raises ApiError instead of leaking aiohttp errors.
+
+    handle_success_response deliberately passes a non-JSON body through, so the
+    parse failure surfaces here - e.g. a proxy returning an HTML error page.
+    """
+
+    async def fake_get(*_args, **_kwargs):
+        return _UnparsableResponse(exc)
+
+    auth.async_get_request = fake_get
+
+    with pytest.raises(ApiError, match="Invalid response when listing webhooks"):
+        await auth.async_list_webhooks()
+
+
+async def test_list_webhooks_debug_log_redacts_the_url(auth, caplog):
+    """DEBUG is what users enable to file a bug report, so it reaches issues.
+
+    The registered URL must therefore never reach the log in full: anyone
+    holding it can POST forged Netatmo events into that user's instance.
+    """
+    _stub(auth, "get", {"status": "ok", "body": [{"url": FAKE_CLOUDHOOK}]})
+
+    with caplog.at_level(logging.DEBUG, logger="pyatmo.auth"):
+        await auth.async_list_webhooks()
+
+    assert FAKE_SECRET not in caplog.text
+    for length in range(REDACTED_TAIL_LENGTH + 1, len(FAKE_SECRET) + 1):
+        assert FAKE_SECRET[-length:] not in caplog.text
+    assert "list_webhooks: 1 registered" in caplog.text
+    assert "https://hooks.nabu.casa/...9Qb=" in caplog.text
+
+
+async def test_list_webhooks_debug_log_counts_every_url(auth, caplog):
+    """The count is the useful part, and it stays truthful for several hooks."""
+    _stub(
+        auth,
+        "get",
+        {
+            "status": "ok",
+            "body": [
+                {"url": "https://a.example.com/s3cr3t-aaaa"},
+                {"url": "https://b.example.com/s3cr3t-bbbb"},
+            ],
+        },
+    )
+
+    with caplog.at_level(logging.DEBUG, logger="pyatmo.auth"):
+        await auth.async_list_webhooks()
+
+    assert "list_webhooks: 2 registered" in caplog.text
+    assert "s3cr3t" not in caplog.text
+    assert "https://a.example.com/...aaaa" in caplog.text
+    assert "https://b.example.com/...bbbb" in caplog.text
+
+
+async def test_list_webhooks_debug_log_reports_zero(auth, caplog):
+    """An empty listing is the interesting case for a health check."""
+    _stub(auth, "get", {"status": "ok", "body": []})
+
+    with caplog.at_level(logging.DEBUG, logger="pyatmo.auth"):
+        await auth.async_list_webhooks()
+
+    assert "list_webhooks: 0 registered" in caplog.text
+
+
+class _ReprResponse(MockResponse):
+    """A response whose repr matches aiohttp's ClientResponse.__repr__.
+
+    aiohttp renders ``<ClientResponse(<request url>) [<status> <reason>]>``
+    followed by the response headers, so a repr can only leak what the request
+    URL carried.
+    """
+
+    def __init__(self, url, status=200, headers=None):
+        super().__init__({"status": "ok"}, status, headers)
+        self.url = url
+
+    def __repr__(self):
+        return f"<ClientResponse({self.url}) [{self.status} OK]>\n{self.headers}\n"
+
+
+class _RecordingSession:
+    """Session capturing how the request was built, returning a repr-faithful response."""
+
+    def __init__(self):
+        self.seen = {}
+
+    def post(self, url, **kwargs):
+        self.seen["url"] = url
+        self.seen.update(kwargs)
+        query = kwargs.get("params") or {}
+        rendered = f"{url}?{urlencode(query)}" if query else url
+        return _ReprResponse(rendered)
+
+
+async def test_addwebhook_sends_the_url_in_the_body_not_the_query():
+    """The registration URL must stay out of the request URL.
+
+    A webhook URL is a capability URL - possession of it is the whole
+    credential. ``async_addwebhook`` finishes with ``LOG.debug("addwebhook:
+    %s", resp)``, and an aiohttp ``ClientResponse`` repr renders the *request*
+    URL, so that debug line is only safe while the webhook URL travels in the
+    JSON body. Moving it to ``params`` would put it in the query string, the
+    response repr and every debug log from there on.
+
+    ``test_addwebhook_debug_log_does_not_leak_the_url`` does not cover this:
+    ``_RecordingSession.post`` builds its ``_ReprResponse`` from the bare
+    ``url`` argument, so a regression to ``params={"url": ...}`` would still
+    leave that test green.
+    """
+    session = _RecordingSession()
+    auth = _Auth(websession=session)
+
+    await auth.async_addwebhook(FAKE_CLOUDHOOK)
+
+    assert session.seen["url"] == "https://api.netatmo.com/webhooks/v1"
+    assert session.seen["json"] == {"url": FAKE_CLOUDHOOK}
+    assert "params" not in session.seen
+    assert "data" not in session.seen
+    assert FAKE_SECRET not in session.seen["url"]
+
+
+async def test_addwebhook_debug_log_does_not_leak_the_url(caplog):
+    """The addwebhook debug line renders a response, never the registered URL."""
+    auth = _Auth(websession=_RecordingSession())
+
+    with caplog.at_level(logging.DEBUG, logger="pyatmo.auth"):
+        await auth.async_addwebhook(FAKE_CLOUDHOOK)
+
+    assert FAKE_SECRET not in caplog.text
+    # Percent-encoded too: a URL smuggled into the query string reaches the
+    # response repr with its "=" as "%3D", so the raw secret would not match.
+    assert quote(FAKE_SECRET, safe="") not in caplog.text
+    assert FAKE_SECRET.rstrip("=") not in caplog.text
+    assert "hooks.nabu.casa" not in caplog.text
+    assert "addwebhook:" in caplog.text
+
+
+async def test_get_request_uses_bearer_token_and_returns_response():
+    """The GET transport sends the bearer header and returns the response."""
+    resp = MockResponse(
+        {"status": "ok", "body": [{"url": "https://example.com/hook"}]},
+        200,
+        headers={"content-type": "application/json"},
+    )
+    seen = {}
+
+    class _Session:
+        def get(self, url, **kwargs):
+            seen["url"] = url
+            seen.update(kwargs)
+            return resp
+
+    auth = _Auth(websession=_Session())
+
+    assert await auth.async_list_webhooks() == ["https://example.com/hook"]
+    assert seen["url"] == "https://api.netatmo.com/webhooks/v1"
+    assert seen["headers"] == {"Authorization": "Bearer token"}
+
+
+async def test_get_request_error_response_raises_api_error():
+    """A non-ok response on the GET path goes through the shared error handling."""
+
+    class _Session:
+        def get(self, _url, **_kwargs):
+            return MockResponse({"error": {"code": 2, "message": "nope"}}, 400)
+
+    auth = _Auth(websession=_Session())
+
+    with pytest.raises(ApiError):
+        await auth.async_list_webhooks()
+
+
+async def test_get_api_request_retries_then_succeeds(auth):
+    """A transient 429/code-11 on the GET path is retried, then succeeds."""
+    success = MockResponse({"status": "ok"}, 200)
+    calls = 0
+    busy = "busy"
+
+    async def flaky(*_args, **_kwargs):
+        nonlocal calls
+        calls += 1
+        if calls < 3:
+            raise ApiTooManyRequestError(busy, retry_after=0.0)
+        return success
+
+    auth.async_get_request = flaky
+
+    result = await auth.async_get_api_request(endpoint="webhooks/v1/")
+
+    assert result is success
+    assert calls == 3
+
+
+async def test_get_api_request_reraises_after_exhaustion(auth):
+    """Persistent 429/code-11 reraises ApiTooManyRequestError after MAX_RETRIES."""
+    calls = 0
+    busy = "busy"
+
+    async def always_busy(*_args, **_kwargs):
+        nonlocal calls
+        calls += 1
+        raise ApiTooManyRequestError(busy, retry_after=0.0)
+
+    auth.async_get_request = always_busy
+
+    with pytest.raises(ApiTooManyRequestError):
+        await auth.async_get_api_request(endpoint="webhooks/v1/")
+
+    assert calls == MAX_RETRIES
+
+
+async def test_handle_error_400_code_21_stays_generic(auth):
+    """400 + code 21 is a plain ApiError carrying the code.
+
+    Code 21 is a generic invalid-parameter code, not "invalid home id": the
+    auth layer sees only a status, a code and a URL, so it cannot know what the
+    caller asked for. Translating it is the caller's job.
+    """
+    resp = MockResponse({"error": {"code": 21, "message": "Invalid home_id"}}, 400)
+
+    with pytest.raises(ApiError) as exc_info:
+        await auth.handle_error_response(resp, 400, "https://x/y")
+
+    assert not isinstance(exc_info.value, InvalidHomeError)
+    assert exc_info.value.code == 21
+
+
+async def test_addwebhook_rejected_url_is_not_an_invalid_home():
+    """A URL Netatmo refuses must not surface as a rejected home.
+
+    The legacy ``api/addwebhook`` answered a URL whose host does not resolve
+    with the very same ``400`` + code 21 that ``/homestatus`` answers a
+    rejected home id with (both measured 2026-08-14, against the legacy
+    endpoint; whether ``POST webhooks/v1`` rejects an unresolvable host the
+    same way is assumed, not measured). What this pins does not depend on that:
+    code 21 must not become ``InvalidHomeError`` anywhere, and that pairing is
+    still reachable from ``/homestatus``. A consumer acting on
+    ``InvalidHomeError`` would stop polling a perfectly good home because of a
+    webhook registration mistake.
+    """
+
+    class _Session:
+        def post(self, _url, **_kwargs):
+            return MockResponse(
+                {"error": {"code": 21, "message": "Invalid url parameter"}},
+                400,
+            )
+
+    auth = _Auth(websession=_Session())
+
+    with pytest.raises(ApiError) as exc_info:
+        await auth.async_addwebhook("https://does-not-resolve.invalid/hook")
+
+    assert not isinstance(exc_info.value, InvalidHomeError)
+    assert exc_info.value.code == 21
+
+
+async def test_handle_error_exposes_status_and_code(auth):
+    """The exception carries what the caller needs to interpret the failure."""
+    resp = MockResponse({"error": {"code": 21, "message": "Invalid home_id"}}, 400)
+
+    with pytest.raises(ApiError) as exc_info:
+        await auth.handle_error_response(resp, 400, "https://x/y")
+
+    assert exc_info.value.status == 400
+    assert exc_info.value.code == 21
+
+
+async def test_handle_error_unparsable_body_exposes_status_without_code(auth):
+    """An unreadable body yields the status it came with and no code."""
+    resp = _UnparsableResponse(ContentTypeError(None, ()))
+
+    with pytest.raises(ApiError) as exc_info:
+        await auth.handle_error_response(resp, 400, "https://x/y")
+
+    assert exc_info.value.status == 400
+    assert exc_info.value.code is None
+
+
+async def test_handle_error_409_string_code_renders_the_status_name(auth):
+    """A ``webhooks/v1`` conflict renders a complete message and keeps its code.
+
+    ``POST webhooks/v1`` answers a second registration with ``409`` and a
+    *string* code (measured 2026-08-15). Without a 409 entry in ``ERRORS`` the
+    message rendered with an empty middle field.
+    """
+    resp = MockResponse(
+        {"error": {"code": "WH009", "message": "webhook limit reached"}},
+        409,
+    )
+
+    with pytest.raises(ApiError) as exc_info:
+        await auth.handle_error_response(resp, 409, "https://x/y")
+
+    assert "409 - Conflict - webhook limit reached (WH009)" in str(exc_info.value)
+    assert exc_info.value.status == 409
+    assert exc_info.value.code == "WH009"
+
+
+async def test_handle_error_string_code_never_matches_an_integer_code(auth):
+    """A string code must not be mistaken for one of the integer codes.
+
+    The auth layer branches on ``code == 11`` / ``code == 26``; a string code
+    equals neither, so the generic ``ApiError`` is raised and the code reaches
+    the caller unconverted.
+    """
+    resp = MockResponse(
+        {"error": {"code": "WH009", "message": "webhook limit reached"}},
+        429,
+    )
+
+    with pytest.raises(ApiError) as exc_info:
+        await auth.handle_error_response(resp, 429, "https://x/y")
+
+    assert not isinstance(exc_info.value, ApiTooManyRequestError)
+    assert "429 - Too Many Requests - " in str(exc_info.value)
+    assert exc_info.value.code == "WH009"
+    assert exc_info.value.code != CONCURRENCY_ERROR_CODE
+
+
+async def test_handle_error_403_string_code_is_not_throttling(auth):
+    """The 403 branch is likewise keyed on the integer code 26."""
+    resp = MockResponse({"error": {"code": "WH001", "message": "nope"}}, 403)
+
+    with pytest.raises(ApiError) as exc_info:
+        await auth.handle_error_response(resp, 403, "https://x/y")
+
+    assert not isinstance(exc_info.value, ApiThrottlingError)
+    assert exc_info.value.code == "WH001"
+    assert exc_info.value.code != THROTTLING_ERROR_CODE
+
+
+async def test_handle_error_400_without_code_21_stays_generic(auth):
+    """Any other 400 is an ApiError too - no error code is special-cased here."""
+    resp = MockResponse({"error": {"code": 2, "message": "Invalid access token"}}, 400)
+
+    with pytest.raises(ApiError):
+        await auth.handle_error_response(resp, 400, "https://x/y")
+
+
+async def test_handle_error_names_the_home_from_params(auth):
+    """The rejected home id reaches the exception message.
+
+    The home id travels in the POST body, not the URL, so without this a
+    consumer cannot tell which of its homes the API rejected.
+    """
+    resp = MockResponse({"error": {"code": 21, "message": "Invalid home_id"}}, 400)
+
+    with pytest.raises(ApiError) as exc_info:
+        await auth.handle_error_response(
+            resp,
+            400,
+            "https://x/homestatus",
+            params={"home_id": "5ed02c730474377f3443794a"},
+        )
+
+    assert "for home 5ed02c730474377f3443794a" in str(exc_info.value)
+
+
+@pytest.mark.parametrize(
+    "params",
+    [None, {}, {"app_types": "app_security"}],
+)
+async def test_handle_error_without_home_id_keeps_message_unchanged(auth, params):
+    """A request carrying no home id logs and raises exactly as it did before."""
+    resp = MockResponse({"error": {"code": 2, "message": "Invalid access token"}}, 400)
+
+    with pytest.raises(ApiError) as exc_info:
+        await auth.handle_error_response(resp, 400, "https://x/y", params=params)
+
+    message = str(exc_info.value)
+    assert "for home" not in message
+    assert message.endswith("when accessing 'https://x/y'")
+
+
+async def test_handle_error_unparsable_body_names_the_home(auth):
+    """The fallback message for an unreadable body also names the home."""
+    resp = _UnparsableResponse(ContentTypeError(None, ()))
+
+    with pytest.raises(ApiError) as exc_info:
+        await auth.handle_error_response(
+            resp,
+            400,
+            "https://x/homestatus",
+            params={"home_id": "5ed02c730474377f3443794a"},
+        )
+
+    assert "for home 5ed02c730474377f3443794a" in str(exc_info.value)
+
+
+async def test_process_response_logs_the_home_id(auth, caplog):
+    """The debug line names the home the failed request was for."""
+    resp = MockResponse({"error": {"code": 21, "message": "Invalid home_id"}}, 400)
+
+    with (
+        caplog.at_level(logging.DEBUG, logger="pyatmo.auth"),
+        pytest.raises(ApiError),
+    ):
+        await auth.process_response(
+            resp,
+            "https://x/homestatus",
+            params={"home_id": "5ed02c730474377f3443794a"},
+        )
+
+    assert "for home 5ed02c730474377f3443794a" in caplog.text
+
+
+async def test_process_response_log_unchanged_without_home_id(auth, caplog):
+    """Without a home id the debug line carries no empty 'for home' noise."""
+    resp = MockResponse({"error": {"code": 2, "message": "nope"}}, 400)
+
+    with caplog.at_level(logging.DEBUG, logger="pyatmo.auth"), pytest.raises(ApiError):
+        await auth.process_response(resp, "https://x/y")
+
+    assert "The Netatmo API returned" in caplog.text
+    assert "for home" not in caplog.text
+
+
+async def test_error_path_never_leaks_the_webhook_url(auth, caplog):
+    """Only the home id is taken from params - the webhook_id stays secret.
+
+    async_post_request also carries ``params={"url": ...}`` for webhook
+    registration, and that URL embeds the secret webhook_id.
+    """
+    webhook_url = "https://hass.example/api/webhook/s3cr3t-webhook-id"
+    resp = MockResponse({"error": {"code": 2, "message": "nope"}}, 400)
+
+    with (
+        caplog.at_level(logging.DEBUG, logger="pyatmo.auth"),
+        pytest.raises(ApiError) as exc_info,
+    ):
+        await auth.process_response(
+            resp,
+            "https://x/addwebhook",
+            params={"url": webhook_url},
+        )
+
+    assert "s3cr3t-webhook-id" not in str(exc_info.value)
+    assert "s3cr3t-webhook-id" not in caplog.text
+
+
+async def test_post_request_passes_params_to_the_error_path():
+    """The POST transport hands its params to the shared error handling."""
+
+    class _Session:
+        def post(self, _url, **_kwargs):
+            return MockResponse(
+                {"error": {"code": 21, "message": "Invalid home_id"}},
+                400,
+            )
+
+    auth = _Auth(websession=_Session())
+
+    with pytest.raises(ApiError) as exc_info:
+        await auth.async_post_request(
+            "https://x/api/homestatus",
+            params={"home_id": "5ed02c730474377f3443794a"},
+        )
+
+    assert "for home 5ed02c730474377f3443794a" in str(exc_info.value)
+
+
+async def test_get_request_passes_params_to_the_error_path():
+    """The GET transport hands its params to the shared error handling."""
+
+    class _Session:
+        def get(self, _url, **_kwargs):
+            return MockResponse(
+                {"error": {"code": 21, "message": "Invalid home_id"}},
+                400,
+            )
+
+    auth = _Auth(websession=_Session())
+
+    with pytest.raises(ApiError) as exc_info:
+        await auth.async_get_request(
+            "https://x/api/homestatus",
+            params={"home_id": "5ed02c730474377f3443794a"},
+        )
+
+    assert "for home 5ed02c730474377f3443794a" in str(exc_info.value)
+
+
+class _FakeDeleteSession:
+    """Minimal websession recording the delete call it received.
+
+    ``MockResponse`` is itself an async context manager (``tests/common.py``),
+    so it can be returned straight from ``delete()``.
+    """
+
+    def __init__(self, payload, status=200):
+        self.payload = payload
+        self.status = status
+        self.seen = {}
+
+    def delete(self, url, **kwargs):
+        self.seen = {"url": url, **kwargs}
+        return MockResponse(self.payload, self.status)
+
+
+async def test_delete_request_issues_a_delete_with_the_bearer_token():
+    """A DELETE carries the access token and reaches the given url."""
+    session = _FakeDeleteSession({"status": "ok"})
+    auth = _Auth(websession=session)
+
+    await auth.async_delete_request(url="https://api.netatmo.com/webhooks/v1")
+
+    assert session.seen["url"] == "https://api.netatmo.com/webhooks/v1"
+    assert session.seen["headers"]["Authorization"] == "Bearer token"
+
+
+async def test_delete_api_request_appends_the_endpoint_to_the_base_url():
+    """The endpoint is joined to the base url, as the get wrapper does."""
+    session = _FakeDeleteSession({"status": "ok"})
+    auth = _Auth(websession=session)
+
+    await auth.async_delete_api_request(endpoint="webhooks/v1")
+
+    assert session.seen["url"] == "https://api.netatmo.com/webhooks/v1"
+
+
+async def test_delete_request_raises_api_error_on_error_status():
+    """A DELETE goes through the same error handling as every other verb."""
+    session = _FakeDeleteSession({"error": {"code": "WH404", "message": "nope"}}, 404)
+    auth = _Auth(websession=session)
+
+    with pytest.raises(ApiError) as exc_info:
+        await auth.async_delete_request(url="https://api.netatmo.com/webhooks/v1")
+
+    assert exc_info.value.status == 404
+    assert exc_info.value.code == "WH404"
+
+
+async def test_delete_api_request_retries_then_succeeds(auth):
+    """A transient 429/code-11 on the DELETE path is retried, then succeeds.
+
+    ``DELETE /webhooks/v1`` takes no body and clears the application's single
+    webhook, so repeating it converges on the same state - retrying is safe on
+    the merits, not merely for symmetry with the get and post wrappers.
+    """
+    success = MockResponse({"status": "ok"}, 200)
+    calls = 0
+    busy = "busy"
+
+    async def flaky(*_args, **_kwargs):
+        nonlocal calls
+        calls += 1
+        if calls < 3:
+            raise ApiTooManyRequestError(busy, retry_after=0.0)
+        return success
+
+    auth.async_delete_request = flaky
+
+    result = await auth.async_delete_api_request(endpoint="webhooks/v1")
+
+    assert result is success
+    assert calls == 3
+
+
+async def test_dropwebhook_issues_a_delete_to_webhooks_v1(auth):
+    """Unregistering uses DELETE, not a post to the legacy endpoint."""
+    seen = _stub(auth, "delete")
+
+    await auth.async_dropwebhook()
+
+    assert seen["url"] == "https://api.netatmo.com/webhooks/v1"
+
+
+async def test_dropwebhook_sends_no_app_types_parameter(auth):
+    """The legacy app_types parameter has no meaning on the v1 endpoint."""
+    seen = _stub(auth, "delete")
+
+    await auth.async_dropwebhook()
+
+    assert seen.get("params") is None
+
+
+async def test_dropwebhook_timeout_raises_api_error(auth):
+    """A timeout is still reported as an ApiError, as before."""
+    _stub(auth, "delete", exc=TimeoutError)
+
+    with pytest.raises(ApiError, match="timed out"):
+        await auth.async_dropwebhook()
+
+
+async def test_addwebhook_posts_json_to_webhooks_v1(auth):
+    """Nothing registered: a single POST with a JSON body."""
+    posted = _stub(auth, "post")
+
+    await auth.async_addwebhook("https://example.com/hook")
+
+    assert posted["url"] == "https://api.netatmo.com/webhooks/v1"
+    assert posted["params"] == {"json": {"url": "https://example.com/hook"}}
+
+
+async def test_addwebhook_surfaces_a_failure_after_the_delete_succeeded(auth):
+    """A retry POST that fails after a successful delete reaches the caller unchanged.
+
+    Nothing is rolled back: the old registration is gone and the new one was
+    never made. A plain retry then finds nothing registered, so its first POST
+    succeeds and the call self-heals.
+    """
+    conflict = ApiError("409 - Conflict - limit (WH009)", status=409, code="WH009")
+    failure = ApiError("400 - Bad Request - nope (21)", status=400, code=21)
+    posts = _stub_sequence(auth, "post", [conflict, failure])
+    deleted = _stub(auth, "delete")
+
+    with pytest.raises(ApiError) as exc_info:
+        await auth.async_addwebhook("https://example.com/hook")
+
+    assert deleted["url"] == "https://api.netatmo.com/webhooks/v1"
+    assert len(posts) == 2
+    assert exc_info.value.code == 21
+
+
+async def test_addwebhook_delete_timeout_does_not_claim_registration_timed_out(auth):
+    """A timeout removing the incumbent must not be reported as a registration one.
+
+    The retry registration was never attempted, and the delete may well have
+    gone through - so the caller may have been left with no webhook at all, the
+    opposite of what "registration timed out" implies.
+    """
+    conflict = ApiError("409 - Conflict - limit (WH009)", status=409, code="WH009")
+    posts = _stub_sequence(auth, "post", [conflict])
+    _stub(auth, "delete", exc=TimeoutError)
+
+    with pytest.raises(ApiError) as exc_info:
+        await auth.async_addwebhook("https://example.com/hook")
+
+    message = str(exc_info.value).lower()
+    assert "timed out" in message
+    assert "removal" in message
+    assert "registration timed out" not in message
+    assert len(posts) == 1
+
+
+async def test_addwebhook_timeout_raises_api_error(auth):
+    """A timeout is still reported as an ApiError, as before.
+
+    The POST is the step that names registration - the removal reports its own
+    timeout, so a caller can tell the two apart.
+    """
+    _stub(auth, "post", exc=TimeoutError)
+
+    with pytest.raises(ApiError, match="registration timed out"):
+        await auth.async_addwebhook("https://example.com/hook")
+
+
+async def test_addwebhook_registers_without_listing_first(auth):
+    """Nothing registered: one POST, and the listing is never consulted."""
+    listed = _stub(auth, "get", {"status": "ok", "body": []})
+    posted = _stub(auth, "post")
+
+    await auth.async_addwebhook("https://example.com/hook")
+
+    assert posted["params"] == {"json": {"url": "https://example.com/hook"}}
+    assert listed == {}
+
+
+async def test_addwebhook_clears_and_retries_on_conflict(auth):
+    """409 means one is already registered: clear it, then register again."""
+    conflict = ApiError("409 - Conflict - limit (WH009)", status=409, code="WH009")
+    posts = _stub_sequence(
+        auth, "post", [conflict, MockResponse({"status": "ok"}, 200)]
+    )
+    deleted = _stub(auth, "delete")
+
+    await auth.async_addwebhook("https://example.com/hook")
+
+    assert len(posts) == 2
+    assert deleted["url"] == "https://api.netatmo.com/webhooks/v1"
+    assert posts[1]["params"] == {"json": {"url": "https://example.com/hook"}}
+
+
+async def test_addwebhook_re_registers_the_same_url(auth):
+    """Re-registering an unchanged URL is NOT a no-op.
+
+    The listing reports deliverable hooks, not registered ones, so a hook
+    Netatmo has stopped delivering to still has to be cleared and posted
+    again -- that is the only way to re-arm it.
+    """
+    conflict = ApiError("409 - Conflict - limit (WH009)", status=409, code="WH009")
+    posts = _stub_sequence(
+        auth, "post", [conflict, MockResponse({"status": "ok"}, 200)]
+    )
+    deleted = _stub(auth, "delete")
+
+    await auth.async_addwebhook("https://example.com/hook")
+
+    assert len(posts) == 2
+    assert deleted != {}
+
+
+async def test_addwebhook_does_not_retry_a_second_conflict(auth):
+    """A conflict surviving the removal is surfaced, not retried forever."""
+    conflict = ApiError("409 - Conflict - limit (WH009)", status=409, code="WH009")
+    posts = _stub_sequence(auth, "post", [conflict, conflict])
+    _stub(auth, "delete")
+
+    with pytest.raises(ApiError) as exc_info:
+        await auth.async_addwebhook("https://example.com/hook")
+
+    assert exc_info.value.status == 409
+    assert len(posts) == 2
+
+
+async def test_addwebhook_surfaces_a_non_conflict_error(auth):
+    """Any other error propagates without touching the registration."""
+    _stub(auth, "post", exc=ApiError("400 - Bad request", status=400, code=21))
+    deleted = _stub(auth, "delete")
+
+    with pytest.raises(ApiError) as exc_info:
+        await auth.async_addwebhook("https://example.com/hook")
+
+    assert exc_info.value.status == 400
+    assert deleted == {}
+
+
+async def test_handle_error_names_the_home_from_a_json_body(auth):
+    """Write endpoints nest the home id in the JSON body, not the params."""
+    resp = MockResponse({"error": {"code": 7, "message": "nope"}}, 500)
+    params = {"json": {"home": {"id": "5ed02c730474377f3443794a", "foo": "bar"}}}
+
+    with pytest.raises(ApiError) as exc_info:
+        await auth.handle_error_response(resp, 500, "https://x/y", params=params)
+
+    assert "for home 5ed02c730474377f3443794a" in str(exc_info.value)
+
+
+async def test_handle_error_json_body_without_a_home_is_unchanged(auth):
+    """A JSON body carrying no home adds no suffix."""
+    resp = MockResponse({"error": {"code": 7, "message": "nope"}}, 500)
+
+    with pytest.raises(ApiError) as exc_info:
+        await auth.handle_error_response(
+            resp,
+            500,
+            "https://x/y",
+            params={"json": {"url": "https://example.com/hook"}},
+        )
+
+    assert "for home" not in str(exc_info.value)
+    assert "example.com" not in str(exc_info.value)
+
+
+async def test_too_many_request_error_carries_status_and_code(auth):
+    """The retryable errors carry the discriminator too, not just ApiError."""
+    resp = MockResponse({"error": {"code": 11, "message": "concurrency"}}, 429)
+
+    with pytest.raises(ApiTooManyRequestError) as exc_info:
+        await auth.handle_error_response(resp, 429, "https://x/y")
+
+    assert exc_info.value.status == 429
+    assert exc_info.value.code == 11
+
+
+async def test_throttling_error_carries_status_and_code(auth):
+    """Same for the 403 throttling case."""
+    resp = MockResponse({"error": {"code": 26, "message": "throttled"}}, 403)
+
+    with pytest.raises(ApiThrottlingError) as exc_info:
+        await auth.handle_error_response(resp, 403, "https://x/y")
+
+    assert exc_info.value.status == 403
+    assert exc_info.value.code == 26

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -6,7 +6,14 @@ import logging
 
 import pytest
 
-from pyatmo.helpers import dict_entries, fix_id, number_or_none, str_or_none
+from pyatmo.exceptions import NoDeviceError
+from pyatmo.helpers import (
+    dict_entries,
+    extract_raw_data,
+    fix_id,
+    number_or_none,
+    str_or_none,
+)
 
 
 @pytest.mark.parametrize(
@@ -165,3 +172,98 @@ def test_number_or_none_stays_quiet_for_absent_value(caplog):
         assert number_or_none(None) is None
 
     assert caplog.text == ""
+
+
+HOME_ID = "5ed02c730474377f3443794a"
+
+# A real /homestatus 200 that answered without a `body` - the production case.
+NO_BODY_RESPONSE = {"status": "ok", "time_server": 1786656837}
+
+
+def test_extract_raw_data_absent_body_names_the_home(caplog):
+    """A body-less 200 names the home in both the log line and the exception.
+
+    This is the production case: /homestatus answers 200 with no `body`, and
+    without the home id two homes on the same account are indistinguishable.
+    """
+    with (
+        caplog.at_level(logging.DEBUG, logger="pyatmo.helpers"),
+        pytest.raises(NoDeviceError) as exc_info,
+    ):
+        extract_raw_data(NO_BODY_RESPONSE, "home", home_id=HOME_ID)
+
+    assert (
+        str(exc_info.value) == f"No device found, errors in response for home {HOME_ID}"
+    )
+    assert f"for home {HOME_ID}" in caplog.text
+
+
+def test_extract_raw_data_absent_body_unchanged_without_home_id(caplog):
+    """With no home id the log line and message are byte-identical to before."""
+    with (
+        caplog.at_level(logging.DEBUG, logger="pyatmo.helpers"),
+        pytest.raises(NoDeviceError) as exc_info,
+    ):
+        extract_raw_data(NO_BODY_RESPONSE, "home")
+
+    assert str(exc_info.value) == "No device found, errors in response"
+    assert caplog.messages == [
+        f"Server response (tag: home): {NO_BODY_RESPONSE}",
+    ]
+
+
+def test_extract_raw_data_empty_tag_data_names_the_home(caplog):
+    """An empty payload for the requested tag names the home too."""
+    resp = {"body": {"home": []}}
+
+    with (
+        caplog.at_level(logging.DEBUG, logger="pyatmo.helpers"),
+        pytest.raises(NoDeviceError) as exc_info,
+    ):
+        extract_raw_data(resp, "home", home_id=HOME_ID)
+
+    assert str(exc_info.value) == f"No device data available for home {HOME_ID}"
+    assert f"for home {HOME_ID}" in caplog.text
+
+
+def test_extract_raw_data_empty_tag_data_unchanged_without_home_id(caplog):
+    """The same branch is untouched when no home id is known."""
+    resp = {"body": {"home": []}}
+
+    with (
+        caplog.at_level(logging.DEBUG, logger="pyatmo.helpers"),
+        pytest.raises(NoDeviceError) as exc_info,
+    ):
+        extract_raw_data(resp, "home")
+
+    assert str(exc_info.value) == "No device data available"
+    assert caplog.messages == [f"Server response (tag: home): {resp}"]
+
+
+def test_extract_raw_data_empty_homes_unchanged_without_home_id(caplog):
+    """/homesdata is account-wide, so its message keeps its exact old wording."""
+    resp = {"body": {"homes": []}}
+
+    with (
+        caplog.at_level(logging.DEBUG, logger="pyatmo.helpers"),
+        pytest.raises(NoDeviceError) as exc_info,
+    ):
+        extract_raw_data(resp, "homes")
+
+    assert str(exc_info.value) == "No homes found"
+    assert caplog.messages == [f"Server response (tag: homes): {resp}"]
+
+
+def test_extract_raw_data_home_id_is_keyword_only_and_last():
+    """Existing positional calls keep working unchanged."""
+    resp = {"body": {"home": [{"id": "a"}]}}
+
+    assert extract_raw_data(resp, "home") == {"home": [{"id": "a"}], "errors": []}
+
+
+def test_extract_raw_data_falsy_home_id_adds_no_noise():
+    """An empty home id renders like no home id at all, not `for home `."""
+    with pytest.raises(NoDeviceError) as exc_info:
+        extract_raw_data(NO_BODY_RESPONSE, "home", home_id="")
+
+    assert str(exc_info.value) == "No device found, errors in response"

--- a/tests/test_home.py
+++ b/tests/test_home.py
@@ -18,6 +18,7 @@ from pyatmo.enums import (
     WindUnit,
 )
 from pyatmo.home import Home, get_temperature_control_mode
+from pyatmo.modules.device_types import DeviceCategory
 from tests.common import MockResponse, load_fixture
 
 
@@ -834,3 +835,41 @@ async def test_async_home_module_reachable_absent_key_preserved(async_account):
         await async_account.async_update_status(home_id)
 
     assert module.reachable is True
+
+
+async def test_home_with_modules_has_status(async_home):
+    """A home carrying modules is pollable."""
+    assert async_home.modules
+    assert async_home.has_status is True
+
+
+async def test_home_without_modules_has_no_status(async_home):
+    """A home carrying no modules has nothing for /homestatus to report."""
+    async_home.modules = {}
+
+    assert async_home.has_status is False
+
+
+async def test_weather_modules_do_not_disqualify_a_home(async_home):
+    """Regression guard: /homestatus does report weather modules.
+
+    Measured 2026-08-13 -- home 6a61e0986124db53ca0248fa holds NAMain and
+    NAModule1, and its /homestatus returns all 7 modules including both. An
+    earlier draft excluded the weather category and would have hidden it.
+    """
+    for module in async_home.modules.values():
+        module.device_category = DeviceCategory.weather
+
+    assert async_home.has_status is True
+
+
+async def test_unmapped_module_keeps_the_home_pollable(async_home):
+    """An unrecognised device type must never hide a home.
+
+    DEVICE_CATEGORY_MAP.get() returns None for mapped types such as NLG and
+    NAPlug, so a missing category cannot mean "not pollable".
+    """
+    for module in async_home.modules.values():
+        module.device_category = None
+
+    assert async_home.has_status is True

--- a/tests/test_release_script.py
+++ b/tests/test_release_script.py
@@ -1,7 +1,10 @@
 """Tests for the release helper script (scripts/release.py)."""
 
 import importlib.util
+import os
 from pathlib import Path
+import subprocess
+from types import SimpleNamespace
 
 import pytest
 
@@ -215,3 +218,233 @@ class TestExtractNotes:
     def test_missing_version_raises(self):
         with pytest.raises(release.ReleaseError):
             release.extract_notes(SAMPLE, "1.2.3")
+
+
+@pytest.fixture
+def git_repo(tmp_path, monkeypatch):
+    """Build a throwaway git repo with one commit and chdir into it.
+
+    Ancestry is a property of real git history, so these tests build history
+    rather than mocking subprocess.
+    """
+
+    def run(*args):
+        subprocess.run(  # noqa: S603 - trusted, hardcoded "git" for a test fixture
+            ["git", *args],  # noqa: S607 - git resolved via PATH is fine here
+            cwd=tmp_path,
+            check=True,
+            stdout=subprocess.DEVNULL,
+        )
+
+    def commit(name, text):
+        (tmp_path / name).write_text(text)
+        run("add", name)
+        run("commit", "-m", f"add {name}")
+
+    # Isolate from the developer's global/system git config (core.hooksPath,
+    # commit.gpgsign, merge.ff, core.excludesFile, includeIf, ...). Per-repo
+    # `git config` overrides can't cover all of these; only excluding the
+    # config files entirely is categorically hermetic.
+    monkeypatch.setenv("GIT_CONFIG_GLOBAL", os.devnull)
+    monkeypatch.setenv("GIT_CONFIG_SYSTEM", os.devnull)
+    run("init", "-b", "main")
+    run("config", "user.email", "test@example.com")
+    run("config", "user.name", "Test")
+    commit("one.txt", "one\n")
+    monkeypatch.chdir(tmp_path)
+    return SimpleNamespace(run=run, commit=commit)
+
+
+class TestIsAncestor:
+    def test_parent_is_ancestor_of_child(self, git_repo):
+        git_repo.commit("two.txt", "two\n")
+        assert release.is_ancestor("HEAD~1", "HEAD") is True
+
+    def test_child_is_not_ancestor_of_parent(self, git_repo):
+        git_repo.commit("two.txt", "two\n")
+        assert release.is_ancestor("HEAD", "HEAD~1") is False
+
+    def test_diverged_branch_is_not_ancestor(self, git_repo):
+        git_repo.run("switch", "-c", "side")
+        git_repo.commit("side.txt", "side\n")
+        git_repo.run("switch", "main")
+        git_repo.commit("main.txt", "main\n")
+        assert release.is_ancestor("side", "main") is False
+
+    def test_true_merge_makes_branch_an_ancestor(self, git_repo):
+        git_repo.run("switch", "-c", "side")
+        git_repo.commit("side.txt", "side\n")
+        git_repo.run("switch", "main")
+        git_repo.commit("main.txt", "main\n")
+        git_repo.run("merge", "--no-ff", "-m", "merge side", "side")
+        assert release.is_ancestor("side", "main") is True
+
+    def test_squashed_merge_does_not_make_branch_an_ancestor(self, git_repo):
+        """The actual bug: a squashed mergeback strands the merged branch."""
+        git_repo.run("switch", "-c", "side")
+        git_repo.commit("side.txt", "side\n")
+        git_repo.run("switch", "main")
+        git_repo.commit("main.txt", "main\n")
+        git_repo.run("merge", "--squash", "side")
+        git_repo.run("commit", "-m", "squashed side")
+        assert release.is_ancestor("side", "main") is False
+
+    @pytest.mark.usefixtures("git_repo")
+    def test_unknown_ref_raises(self):
+        with pytest.raises(release.ReleaseError, match="git merge-base failed"):
+            release.is_ancestor("no-such-ref", "HEAD")
+
+    def test_shallow_clone_raises(self, git_repo, tmp_path_factory, monkeypatch):
+        """A depth-1 clone severs the merge commit's parents.
+
+        ``side`` really is an ancestor of ``main`` (a true merge, as in the test
+        above), but in a shallow clone git can no longer see far enough back to
+        tell, and answers "not reachable" instead of raising. A silent false
+        negative here would let the release gate wave through exactly the drift
+        it exists to catch, so this must raise rather than return ``False``.
+        """
+        git_repo.run("switch", "-c", "side")
+        git_repo.commit("side.txt", "side\n")
+        git_repo.run("switch", "main")
+        git_repo.commit("main.txt", "main\n")
+        git_repo.run("merge", "--no-ff", "-m", "merge side", "side")
+
+        origin = Path.cwd()
+        clone_dir = tmp_path_factory.mktemp("shallow-clone")
+        subprocess.run(  # noqa: S603 - trusted, hardcoded "git" for a test fixture
+            [  # noqa: S607 - git resolved via PATH is fine here
+                "git",
+                "clone",
+                "--depth",
+                "1",
+                "--no-single-branch",
+                f"file://{origin}",
+                str(clone_dir),
+            ],
+            check=True,
+            stdout=subprocess.DEVNULL,
+        )
+        monkeypatch.chdir(clone_dir)
+
+        with pytest.raises(release.ReleaseError, match="shallow"):
+            release.is_ancestor("origin/side", "origin/main")
+
+
+class TestCheckAncestryCommand:
+    def test_exits_zero_when_reachable(self, git_repo, capsys, monkeypatch):
+        monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
+        git_repo.commit("two.txt", "two\n")
+        assert release.main(["--check-ancestry", "HEAD~1", "HEAD"]) == 0
+        captured = capsys.readouterr()
+        assert "HEAD~1 is an ancestor of HEAD" in captured.out
+        assert captured.err == ""
+
+    def test_exits_one_when_not_reachable(self, git_repo, capsys, monkeypatch):
+        monkeypatch.setenv("GITHUB_ACTIONS", "true")
+        git_repo.run("switch", "-c", "side")
+        git_repo.commit("side.txt", "side\n")
+        git_repo.run("switch", "main")
+        git_repo.commit("main.txt", "main\n")
+        assert release.main(["--check-ancestry", "side", "main"]) == 1
+        captured = capsys.readouterr()
+        assert captured.out == ""
+        assert "::error::side is not an ancestor of main" in captured.err
+        assert "Merge side into main" in captured.err
+        assert "See docs/release-process.md for recovery steps." in captured.err
+
+    @pytest.mark.usefixtures("git_repo")
+    def test_reports_release_errors_as_annotations(self, capsys, monkeypatch):
+        """A real bad ref must fail loudly, not crash with a traceback."""
+        monkeypatch.setenv("GITHUB_ACTIONS", "true")
+        assert release.main(["--check-ancestry", "no-such-ref", "HEAD"]) == 1
+        captured = capsys.readouterr()
+        assert "::error::git merge-base failed" in captured.err
+        assert captured.out == ""
+
+    @pytest.mark.usefixtures("git_repo")
+    def test_requires_exactly_two_refs(self):
+        with pytest.raises(SystemExit) as exc:
+            release.main(["--check-ancestry", "HEAD"])
+        assert exc.value.code == 2
+
+    @pytest.mark.usefixtures("git_repo")
+    def test_is_mutually_exclusive_with_bump(self):
+        with pytest.raises(SystemExit) as exc:
+            release.main(["--check-ancestry", "HEAD~1", "HEAD", "--bump", "patch"])
+        assert exc.value.code == 2
+
+    @pytest.mark.usefixtures("git_repo")
+    def test_is_mutually_exclusive_with_notes(self):
+        with pytest.raises(SystemExit) as exc:
+            release.main(["--check-ancestry", "HEAD~1", "HEAD", "--notes", "1.2.3"])
+        assert exc.value.code == 2
+
+    @pytest.mark.usefixtures("git_repo")
+    def test_dry_run_only_applies_to_bump(self):
+        with pytest.raises(SystemExit) as exc:
+            release.main(["--check-ancestry", "HEAD~1", "HEAD", "--dry-run"])
+        assert exc.value.code == 2
+
+
+class TestMainRequiresACommand:
+    @pytest.mark.usefixtures("git_repo")
+    def test_bare_invocation_exits_two(self):
+        with pytest.raises(SystemExit) as exc:
+            release.main([])
+        assert exc.value.code == 2
+
+
+class TestBumpCommandErrorPath:
+    def test_empty_unreleased_reports_plain_error_via_main(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """Assert ``main()`` catches the empty-``[unreleased]`` ``ReleaseError``.
+
+        ``_cmd_bump`` has no local try/except; ``main()`` must catch the
+        ``ReleaseError`` from ``finalize_changelog``'s empty-``[unreleased]``
+        guard and report it via ``_fail``, exactly as documented in
+        docs/release-process.md.
+        """
+        monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
+        changelog = tmp_path / "CHANGELOG.md"
+        changelog.write_text(EMPTY_UNRELEASED, encoding="utf-8")
+        monkeypatch.setattr(release, "CHANGELOG", changelog)
+
+        assert release.main(["--bump", "minor", "--dry-run"]) == 1
+        captured = capsys.readouterr()
+        assert (
+            captured.err
+            == "error: the [unreleased] section has no entries; nothing to release\n"
+        )
+        assert captured.out == ""
+
+
+class TestFail:
+    def test_plain_prefix_without_github_actions(self, capsys, monkeypatch):
+        monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
+        assert release._fail("boom") == 1  # noqa: SLF001 - testing the private reporter
+        captured = capsys.readouterr()
+        assert captured.err == "error: boom\n"
+        assert captured.out == ""
+
+    def test_annotation_prefix_with_github_actions(self, capsys, monkeypatch):
+        monkeypatch.setenv("GITHUB_ACTIONS", "true")
+        assert release._fail("boom") == 1  # noqa: SLF001 - testing the private reporter
+        captured = capsys.readouterr()
+        assert captured.err == "::error::boom\n"
+
+    def test_multiline_message_is_percent_encoded(self, capsys, monkeypatch):
+        monkeypatch.setenv("GITHUB_ACTIONS", "true")
+        release._fail("line one\nline two")  # noqa: SLF001 - testing the private reporter
+        captured = capsys.readouterr()
+        assert captured.err == "::error::line one%0Aline two\n"
+
+    def test_percent_sign_does_not_corrupt_newline_encoding(self, capsys, monkeypatch):
+        # "%" must be encoded first, or an already-produced "%0D" would be
+        # re-escaped into "%250D". A message with both a literal "%" and a CR
+        # pins the order: "%" becomes "%25" and "\r" becomes "%0D", and the two
+        # do not interfere with each other.
+        monkeypatch.setenv("GITHUB_ACTIONS", "true")
+        release._fail("100% done\rretry")  # noqa: SLF001 - testing the private reporter
+        captured = capsys.readouterr()
+        assert captured.err == "::error::100%25 done%0Dretry\n"

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from time import time
+
 import pytest
 
 import pyatmo
@@ -77,6 +79,9 @@ def test_webhook_types_exported_from_package():
         ("connection", "connection", WebhookKind.LIFECYCLE),
         ("disconnection", "disconnection", WebhookKind.LIFECYCLE),
         (None, "NPC-connection", WebhookKind.LIFECYCLE),
+        (None, "NPC-disconnection", WebhookKind.LIFECYCLE),
+        (None, "NACamera-disconnection", WebhookKind.LIFECYCLE),
+        (None, "disconnection", WebhookKind.LIFECYCLE),
         ("something_new", "brand_new_push", WebhookKind.UNKNOWN),
     ],
 )
@@ -242,6 +247,32 @@ async def test_process_webhook_camera_disconnection_then_connection_flips_reacha
     assert result.touched_ids == [camera_id]
     assert len(result.events) == 1
     assert result.events[0].event_type == "connection"
+
+
+@pytest.mark.usefixtures("async_home")
+async def test_process_webhook_camera_disconnection_push_type_only(async_account):
+    """A `*-disconnection` push type with no event_type must still be LIFECYCLE."""
+    home_id = "91763b24c43d3e344f424e8b"
+    camera_id = "12:34:56:00:f1:62"
+    camera = async_account.homes[home_id].modules[camera_id]
+    assert camera.reachable is True
+
+    result = await process_webhook(
+        async_account,
+        {
+            "camera_id": camera_id,
+            "device_id": camera_id,
+            "home_id": home_id,
+            "push_type": "NACamera-disconnection",
+        },
+    )
+    assert result.kind is WebhookKind.LIFECYCLE
+    assert result.lifecycle is LifecycleStatus.DISCONNECTION
+    assert result.refresh_scope == frozenset()
+    assert camera.reachable is False
+    assert result.touched_ids == [camera_id]
+    # No event_type in the payload -> nothing to surface as an event.
+    assert result.events == []
 
 
 async def test_process_webhook_unknown(async_account):
@@ -1856,3 +1887,46 @@ async def test_process_webhook_device_event_diagnosis_event_surfaces(async_accou
     assert result.touched_ids == ["12:34:56:3c:63:b2"]
     assert result.refresh_scope == frozenset()
     assert len(async_account.homes[home_id].modules) == module_count_before
+
+
+@pytest.mark.usefixtures("async_home")
+async def test_process_webhook_records_delivery_time(async_account):
+    """Any processed payload records when it arrived."""
+    assert async_account.last_webhook_at is None
+
+    await process_webhook(async_account, {"push_type": "webhook_activation"})
+
+    assert async_account.last_webhook_at is not None
+
+
+@pytest.mark.usefixtures("async_home")
+async def test_process_webhook_records_delivery_time_for_unknown_payloads(
+    async_account,
+):
+    """An unrecognised payload still proves the webhook path is delivering."""
+    await process_webhook(async_account, {"push_type": "display_change"})
+
+    assert async_account.last_webhook_at is not None
+
+
+async def test_last_webhook_at_records_an_unclassifiable_payload(async_account):
+    """Delivery of anything proves the path works, even if nothing parses.
+
+    The stamp is the first statement of process_webhook for this reason:
+    a payload with no event_type and no push_type returns UNKNOWN through an
+    early return, and must still count as a delivery.
+    """
+    before = time()
+
+    result = await process_webhook(async_account, {})
+
+    assert result.kind is WebhookKind.UNKNOWN
+    assert async_account.last_webhook_at is not None
+    assert async_account.last_webhook_at >= before
+
+
+async def test_last_webhook_at_is_wall_clock(async_account):
+    """Consumers compute an age from it, so it must be comparable to time()."""
+    await async_account.process_webhook({"push_type": "webhook_activation"})
+
+    assert async_account.last_webhook_at == pytest.approx(time(), abs=5)


### PR DESCRIPTION
**Merge this PR with "Create a merge commit"** -- not "Squash and merge",
not "Rebase and merge" -- so `master` stays reachable from `development`
for the mergeback that follows.

### Added

- Report which webhook URLs are registered, so a registration that was dropped
  or overwritten can be detected. A banned webhook is still listed, so this
  proves a webhook is registered - not that anything reaches it
- Record when the last webhook payload arrived, including payloads the library
  cannot classify
- `Home.has_status` tells you up front whether a home can be polled, so the ones
  Netatmo refuses need never be called

### Changed

- A home Netatmo permanently refuses now fails in its own distinct way, so it
  can be dropped rather than retried forever. Existing error handling still
  catches it
- Errors now carry the status and error code Netatmo sent back, so one kind of
  failure can be told apart from another
- Error logs and messages now name the home they came from
- Webhooks are managed through Netatmo's new endpoints

### Fixed

- Error messages for HTTP 409 and 429 name the status instead of leaving a
  blank where it should be
- Webhook URLs are redacted in logs. They are secrets, and debug logs end up in
  bug reports
- Devices belonging to no known home are named in the log
- Stop searching every home for a device that already said which home it is in

## Summary by Sourcery

Improve webhook observability and reliability, make home polling failures actionable, and protect release branch history from squash or rebase mergebacks.

New Features:
- Add webhook registration inspection and delivery timestamps, including unclassified payloads.
- Expose whether homes have pollable status data and distinguish permanently rejected homes with a dedicated API error.

Bug Fixes:
- Improve API error identification and home attribution, correct HTTP status messages, protect webhook secrets in logs, and avoid redundant device-home searches.

Enhancements:
- Migrate webhook management to the webhooks/v1 API and support conflict recovery through deletion and re-registration.

CI:
- Enforce merge-commit ancestry between master and development before releases and require mergeback workflows to use merge commits.

Documentation:
- Document the release process and Home Assistant webhook integration guidance.

Tests:
- Expand coverage for webhook management, error metadata and redaction, home polling behavior, webhook delivery tracking, device handling, and release ancestry checks.

Chores:
- Release version 9.9.0 and update the changelog.