### PR TITLE
Mergeback v9.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [9.9.0] - 2026-08-18
+
 ### Added
 
 - Report which webhook URLs are registered, so a registration that was dropped
@@ -605,6 +607,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix crash when station name is not contained in the backend data
 
+[9.9.0]: https://github.com/jabesq-org/pyatmo/compare/v9.8.0...v9.9.0
 [9.8.0]: https://github.com/jabesq-org/pyatmo/compare/v9.7.0...v9.8.0
 [9.7.0]: https://github.com/jabesq-org/pyatmo/compare/v9.6.0...v9.7.0
 [9.6.0]: https://github.com/jabesq-org/pyatmo/compare/v9.5.0...v9.6.0


### PR DESCRIPTION
Return the release commit and the reset `[unreleased]` scaffold to development.

**Pick "Create a merge commit" from the merge dropdown -- not "Squash and
merge", not "Rebase and merge".** Either of those leaves `master` off
`development`'s history, which makes the next release PR conflict in
`CHANGELOG.md` and makes `setuptools_scm` version development builds from a
stale tag. `release-prepare.yml` refuses to cut a release while that is true.

## Summary by Sourcery

Merge the v9.9.0 release history back into the development branch.

Enhancements:
- Restore the v9.9.0 release entry and comparison link while preserving the development changelog scaffold.

Documentation:
- Update the changelog with the v9.9.0 release date and release history link.