### PR TITLE
fix: report an undeclared status room once, not per poll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Keep `target_position:step` across topology updates, which do not report it
+- Report a room that `/homestatus` returns but the home topology never declared
+  once per room instead of on every poll. Some homes carry a room the user cannot
+  delete, which filled the log with the same warning every minute
 
 ## [9.9.0] - 2026-08-18
 

--- a/src/pyatmo/home.py
+++ b/src/pyatmo/home.py
@@ -98,6 +98,9 @@ class Home:
             s["id"]: Person(home=self, raw_data=s) for s in raw_data.get("persons", [])
         }
         self.events = {}
+        # Room ids seen in /homestatus that the topology never declared. Tracked
+        # so each one is reported once instead of on every poll; see Home.update.
+        self._unknown_room_ids: set[str] = set()
 
         self.temperature_control_mode = get_temperature_control_mode(
             raw_data.get("temperature_control_mode"),
@@ -258,15 +261,28 @@ class Home:
 
         for room in data.get("rooms", []):
             has_an_update = True
-            if room["id"] in self.rooms:
-                self.rooms[room["id"]].update(room)
-            else:
+            room_id = room["id"]
+            if room_id in self.rooms:
+                self.rooms[room_id].update(room)
+                # Re-arm the warning: the topology declares this room again, so
+                # should it drop out later that is fresh news worth reporting.
+                self._unknown_room_ids.discard(room_id)
+            elif room_id not in self._unknown_room_ids:
+                # Some homes (seen on Legrand/Bubendorff) carry a room in
+                # /homestatus that /homesdata never declares, on every poll
+                # forever. The room is skipped either way -- building one needs
+                # the name and type only the topology carries -- but the
+                # condition is not user-fixable, so report it once per id
+                # instead of once per poll.
+                self._unknown_room_ids.add(room_id)
                 LOG.warning(
                     "Room id (%s) not found in known rooms. Known room ids: %s (count=%d)",
-                    room["id"],
+                    room_id,
                     list(self.rooms.keys()),
                     len(self.rooms),
                 )
+            else:
+                LOG.debug("Room id (%s) still not found in known rooms", room_id)
 
         for person_status in data.get("persons", []):
             # if there is a person update, it means the house has been updated

--- a/tests/test_home.py
+++ b/tests/test_home.py
@@ -873,3 +873,86 @@ async def test_unmapped_module_keeps_the_home_pollable(async_home):
         module.device_category = None
 
     assert async_home.has_status is True
+
+
+def _home_warnings(caplog) -> list[str]:
+    """Return the WARNING messages pyatmo.home emitted."""
+    return [
+        record.getMessage()
+        for record in caplog.records
+        if record.name == "pyatmo.home" and record.levelno == logging.WARNING
+    ]
+
+
+async def test_unknown_status_room_warns_once(async_home, caplog):
+    """A /homestatus room absent from the topology is reported once, not per poll.
+
+    Legrand/Bubendorff homes get a phantom room id 0 the API never declares in
+    /homesdata and the user cannot delete, so warning per poll meant one warning
+    a minute forever (jabesq-org/pyatmo#657).
+    """
+    assert "0" not in async_home.rooms
+    status = {"home": {"id": async_home.entity_id, "rooms": [{"id": "0"}]}}
+
+    with caplog.at_level(logging.DEBUG, logger="pyatmo.home"):
+        for _ in range(3):
+            await async_home.update(status)
+
+    warnings = _home_warnings(caplog)
+    assert len(warnings) == 1
+    assert "Room id (0) not found in known rooms" in warnings[0]
+
+    repeats = [
+        record
+        for record in caplog.records
+        if record.name == "pyatmo.home"
+        and record.levelno == logging.DEBUG
+        and "still not found" in record.getMessage()
+    ]
+    assert len(repeats) == 2
+
+
+async def test_unknown_status_room_warns_again_after_topology_churn(async_home, caplog):
+    """Declaring the room in the topology re-arms the warning.
+
+    Dedupe must not turn into permanent silence: an id that becomes known and
+    later drops out of the topology again is fresh news.
+
+    The topology payloads here are deliberately partial, so they also drop the
+    home's modules and schedules -- irrelevant to what this test asserts.
+    """
+    status = {"home": {"id": async_home.entity_id, "rooms": [{"id": "0"}]}}
+
+    with caplog.at_level(logging.DEBUG, logger="pyatmo.home"):
+        await async_home.update(status)
+        assert len(_home_warnings(caplog)) == 1
+
+        # Topology declares room 0: the status room now resolves, which clears
+        # the dedupe entry.
+        async_home.update_topology({"rooms": [{"id": "0"}]})
+        await async_home.update(status)
+        assert len(_home_warnings(caplog)) == 1
+        assert async_home.rooms["0"].entity_id == "0"
+
+        # Withdrawn again: unknown once more, so it warns a second time.
+        async_home.update_topology({"rooms": []})
+        await async_home.update(status)
+        assert len(_home_warnings(caplog)) == 2
+
+
+async def test_known_status_rooms_never_warn(async_home, caplog):
+    """Rooms the topology declares must not trip the unknown-room warning."""
+    known = list(async_home.rooms)
+    assert known
+
+    with caplog.at_level(logging.DEBUG, logger="pyatmo.home"):
+        await async_home.update(
+            {
+                "home": {
+                    "id": async_home.entity_id,
+                    "rooms": [{"id": room_id} for room_id in known],
+                },
+            },
+        )
+
+    assert _home_warnings(caplog) == []


### PR DESCRIPTION
## Summary by Sourcery

Prevent repeated warnings for status rooms missing from the home topology while preserving notifications when topology changes.

Bug Fixes:
- Report undeclared status rooms only once per room instead of repeating the warning on every poll.
- Re-arm unknown-room warnings when topology changes so newly undeclared rooms are reported again.

Tests:
- Add coverage for warning deduplication, topology churn, and valid status rooms.