### PR TITLE
feat: expose VELUX position thresholds and Wi-Fi quality

### DIFF
--- a/fixtures/homesdata_velux.json
+++ b/fixtures/homesdata_velux.json
@@ -15,6 +15,7 @@
             "modules_bridged": [
               "velux_opener_awning",
               "velux_opener_blind",
+              "velux_opener_window",
               "velux_climate_sensor",
               "velux_departure_switch"
             ],
@@ -35,6 +36,14 @@
             "bridge": "velux_gateway_id",
             "room_id": "velux_room_id",
             "velux_type": "blind"
+          },
+          {
+            "id": "velux_opener_window",
+            "type": "NXO",
+            "name": "Bedroom Window",
+            "bridge": "velux_gateway_id",
+            "room_id": "velux_room_id",
+            "velux_type": "window"
           },
           {
             "id": "velux_climate_sensor",
@@ -59,6 +68,7 @@
             "module_ids": [
               "velux_opener_awning",
               "velux_opener_blind",
+              "velux_opener_window",
               "velux_climate_sensor"
             ]
           }

--- a/fixtures/homestatus_velux_home_id.json
+++ b/fixtures/homestatus_velux_home_id.json
@@ -7,6 +7,7 @@
           "id": "velux_gateway_id",
           "type": "NXG",
           "wifi_strength": 44,
+          "wifi_state": "full",
           "locked": true,
           "locking": false,
           "secure": true,
@@ -46,6 +47,21 @@
           "manufacturer": "Netatmo",
           "last_seen": 1776675797,
           "firmware_revision": 14
+        },
+        {
+          "id": "velux_opener_window",
+          "type": "NXO",
+          "bridge": "velux_gateway_id",
+          "current_position": 10,
+          "target_position": 10,
+          "secure_position": 10,
+          "rain_position": 50,
+          "mode": "algo_available",
+          "reachable": true,
+          "velux_type": "window",
+          "manufacturer": "VELUX",
+          "last_seen": 1776675797,
+          "firmware_revision": 48
         },
         {
           "id": "velux_climate_sensor",

--- a/src/pyatmo/modules/velux.py
+++ b/src/pyatmo/modules/velux.py
@@ -26,6 +26,7 @@ class VeluxGatewayMixin(EntityBase):
         """Initialize VELUX gateway data."""
         super().__init__(home, module)
         self.subtype: str | None = None
+        self.wifi_state: str | None = None
         self.firmware_revision_netatmo: int | None = None
         self.firmware_revision_thirdparty: int | None = None
         self.hardware_version: int | None = None
@@ -50,6 +51,8 @@ class VeluxOpenerMixin(EntityBase):
         self.last_seen: int | None = None
         self.manufacturer: str | None = None
         self.mode: str | None = None
+        self.secure_position: int | None = None
+        self.rain_position: int | None = None
         self.silent: bool | None = None
         self.velux_type: str | None = None
 

--- a/tests/test_velux.py
+++ b/tests/test_velux.py
@@ -37,12 +37,14 @@ async def test_async_velux_modules(async_auth):
     assert gateway.device_type == DeviceType.NXG
     assert gateway.device_category is None
     assert gateway.wifi_strength == 44
+    assert gateway.wifi_state == "full"
     assert gateway.locked is True
     assert gateway.locking is False
     assert gateway.secure is True
     assert gateway.modules == [
         "velux_opener_awning",
         "velux_opener_blind",
+        "velux_opener_window",
         "velux_climate_sensor",
         "velux_departure_switch",
     ]
@@ -63,6 +65,20 @@ async def test_async_velux_modules(async_auth):
 
     blind = home.modules["velux_opener_blind"]
     assert blind.name == "Bedroom Blind"
+    assert blind.secure_position is None
+    assert blind.rain_position is None
+
+    window = home.modules["velux_opener_window"]
+    assert isinstance(window, pyatmo.modules.NXO)
+    assert {
+        "velux_type": window.velux_type,
+        "secure_position": window.secure_position,
+        "rain_position": window.rain_position,
+    } == {
+        "velux_type": "window",
+        "secure_position": 10,
+        "rain_position": 50,
+    }
 
     sensor = home.modules["velux_climate_sensor"]
     assert isinstance(sensor, pyatmo.modules.NXS)
@@ -163,6 +179,37 @@ async def test_async_velux_modules(async_auth):
         "max_comfort_humidity": 70,
         "max_comfort_co2": 1150,
     }
+
+
+async def test_velux_status_fields_partial_updates(async_auth):
+    """Preserve optional status values on partial updates, including zero and null."""
+    homesdata = json.loads(load_fixture("homesdata_velux.json"))
+    home = pyatmo.Home(async_auth, homesdata["body"]["homes"][0])
+    gateway = home.modules["velux_gateway_id"]
+    window = home.modules["velux_opener_window"]
+
+    assert gateway.wifi_state is None
+    assert window.secure_position is None
+    assert window.rain_position is None
+
+    await gateway.update({"wifi_state": "low"})
+    await window.update({"secure_position": 0, "rain_position": 50})
+    await gateway.update({"wifi_strength": 65})
+    await window.update({"current_position": 0})
+
+    assert gateway.wifi_state == "low"
+    assert window.secure_position == 0
+    assert window.rain_position == 50
+
+    await window.update({"secure_position": 10, "rain_position": 0})
+    assert window.secure_position == 10
+    assert window.rain_position == 0
+
+    await gateway.update({"wifi_state": None})
+    await window.update({"secure_position": None, "rain_position": None})
+    assert gateway.wifi_state is None
+    assert window.secure_position is None
+    assert window.rain_position is None
 
 
 async def test_async_shutter_nxo(async_auth):


### PR DESCRIPTION
VELUX window position thresholds and gateway Wi-Fi quality are currently discarded from `/homestatus` because the model only updates attributes that have been initialized. Add nullable `NXO.secure_position`, `NXO.rain_position`, and `NXG.wifi_state` so consumers can read the values from existing status updates without additional API requests.

The Android app models both positions as optional integer percentages and Wi-Fi quality as a string. The window fixture uses the app's bundled example values, secure position 10 and rain position 50; these are device-reported values, not library defaults. Wi-Fi quality remains scoped to the VELUX gateway in this change.

Extend the VELUX topology/status fixtures with a window and add coverage for parsing, absent values, zero positions, partial updates, and explicit nulls.

Related to https://github.com/Niek/ha-velux-active/issues/46.

Validation:
- Full suite on Python 3.13: 573 passed; 89.68% coverage.
- Ruff 0.15.12 lint and format checks passed (upstream CI version).
- mypy: no issues in 25 source files.

## Summary by Sourcery

Expose VELUX position thresholds and gateway Wi-Fi quality in home status updates.

New Features:
- Expose VELUX gateway Wi-Fi quality and window secure/rain position thresholds through home status models.

Bug Fixes:
- Preserve optional VELUX status values when processing partial updates, including zero and explicit null values.

Tests:
- Extend VELUX fixtures and tests to cover window topology, value parsing, absent fields, partial updates, zero positions, and null values.